### PR TITLE
Add worker pool telemetry to inspector TUI (#18)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ redis = ["redis>=5.0"]
 inspector = [
     "textual>=8.2.7",
 ]
+worker = [
+    "psutil>=7.2.2",
+]
 
 [project.urls]
 # https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels

--- a/tests/backends/test_redis.py
+++ b/tests/backends/test_redis.py
@@ -7,6 +7,7 @@ import time
 from dataclasses import replace
 from unittest.mock import patch
 
+import pytest
 from django.tasks import default_task_backend
 from django.tasks.base import TaskResultStatus
 from django.utils import timezone
@@ -687,3 +688,148 @@ class TestRedisTaskBackendPeek:
         )
         assert successful == []
         assert failed == []
+
+
+class TestWorkerTelemetrySerialization:
+    """Tests for worker telemetry JSON serialization/deserialization."""
+
+    def test_serialize_deserialize_roundtrip(self):
+        """A WorkerTelemetry snapshot survives a serialize→deserialize roundtrip."""
+        from threadmill.backends.base import (
+            NodeTelemetry,
+            WorkerProcessTelemetry,
+            WorkerTelemetry,
+        )
+        from threadmill.backends.redis import (
+            _deserialize_worker_telemetry,
+            _serialize_worker_telemetry,
+        )
+
+        sampled_at = datetime.datetime.now(tz=datetime.UTC)
+        worker = WorkerProcessTelemetry(
+            name="host:100-0",
+            pid=100,
+            queues=("default", "high"),
+            thread_count=4,
+            task_count=50,
+            tasks_per_minute=12.5,
+            cpu_percent=33.0,
+            memory_bytes=200_000_000,
+            sampled_at=sampled_at,
+        )
+        node = NodeTelemetry(
+            hostname="host",
+            queues=("default", "high"),
+            cpu_percent=45.0,
+            memory_percent=60.0,
+            memory_bytes=8_000_000_000,
+            tasks_per_minute=12.5,
+            workers={"host:100-0": worker},
+            sampled_at=sampled_at,
+        )
+        original = WorkerTelemetry(
+            nodes={"host": node},
+            queues={"default": ("host",), "high": ("host",)},
+            sampled_at=sampled_at,
+        )
+        payload = _serialize_worker_telemetry(original)
+        restored = _deserialize_worker_telemetry(payload)
+        assert restored.sampled_at == original.sampled_at
+        assert set(restored.nodes) == {"host"}
+        assert set(restored.queues) == {"default", "high"}
+        r_node = restored.nodes["host"]
+        assert r_node.hostname == "host"
+        assert r_node.cpu_percent == 45.0
+        assert r_node.memory_bytes == 8_000_000_000
+        assert "host:100-0" in r_node.workers
+        r_worker = r_node.workers["host:100-0"]
+        assert r_worker.pid == 100
+        assert r_worker.queues == ("default", "high")
+        assert r_worker.cpu_percent == 33.0
+
+
+@pytest.mark.integration
+class TestWorkerTelemetryPubSub:
+    """Integration tests for worker telemetry PUB/SUB over real Redis."""
+
+    def test_publish_and_subscribe_roundtrip(self):
+        """publish_worker_telemetry sends, worker_telemetry receives."""
+        backend = RedisTaskBackend(
+            "worker_telemetry_pubsub_test",
+            {
+                "QUEUES": ["default"],
+                "REDIS_URL": "redis://localhost:6379/0",
+                "OPTIONS": {
+                    "result_ttl": datetime.timedelta(seconds=60),
+                },
+            },
+        )
+        try:
+            from threadmill.backends.base import (
+                NodeTelemetry,
+                WorkerProcessTelemetry,
+                WorkerTelemetry,
+            )
+
+            sampled_at = datetime.datetime.now(tz=datetime.UTC)
+            worker = WorkerProcessTelemetry(
+                name="testhost:200-0",
+                pid=200,
+                queues=("default",),
+                thread_count=2,
+                task_count=5,
+                tasks_per_minute=10.0,
+                cpu_percent=20.0,
+                memory_bytes=50_000_000,
+                sampled_at=sampled_at,
+            )
+            node = NodeTelemetry(
+                hostname="testhost",
+                queues=("default",),
+                cpu_percent=30.0,
+                memory_percent=40.0,
+                memory_bytes=4_000_000_000,
+                tasks_per_minute=10.0,
+                workers={"testhost:200-0": worker},
+                sampled_at=sampled_at,
+            )
+            snapshot = WorkerTelemetry(
+                nodes={"testhost": node},
+                queues={"default": ("testhost",)},
+                sampled_at=sampled_at,
+            )
+            backend.publish_worker_telemetry(snapshot)
+
+            # Small delay for pub/sub propagation
+            time.sleep(0.1)
+            received = backend.worker_telemetry()
+            assert "testhost" in received.nodes
+            r_node = received.nodes["testhost"]
+            assert r_node.hostname == "testhost"
+            assert r_node.cpu_percent == 30.0
+            assert "testhost:200-0" in r_node.workers
+            r_worker = r_node.workers["testhost:200-0"]
+            assert r_worker.pid == 200
+            assert r_worker.cpu_percent == 20.0
+            assert "default" in received.queues
+        finally:
+            backend.close()
+
+    def test_worker_telemetry_empty_when_no_messages(self):
+        """worker_telemetry returns an empty snapshot when no messages are waiting."""
+        backend = RedisTaskBackend(
+            "worker_telemetry_empty_test",
+            {
+                "QUEUES": ["default"],
+                "REDIS_URL": "redis://localhost:6379/0",
+                "OPTIONS": {
+                    "result_ttl": datetime.timedelta(seconds=60),
+                },
+            },
+        )
+        try:
+            snapshot = backend.worker_telemetry()
+            assert snapshot.nodes == {}
+            assert snapshot.queues == {}
+        finally:
+            backend.close()

--- a/tests/backends/test_redis.py
+++ b/tests/backends/test_redis.py
@@ -713,13 +713,13 @@ class TestWorkerTelemetrySerialization:
             thread_count=4,
             task_count=50,
             tasks_per_minute=12.5,
-            cpu_percent=33.0,
-            memory_bytes=200_000_000,
             sampled_at=sampled_at,
         )
         node = NodeTelemetry(
             hostname="host",
             queues=("default", "high"),
+            process_count=1,
+            thread_count=4,
             cpu_percent=45.0,
             memory_percent=60.0,
             memory_bytes=8_000_000_000,
@@ -739,13 +739,14 @@ class TestWorkerTelemetrySerialization:
         assert set(restored.queues) == {"default", "high"}
         r_node = restored.nodes["host"]
         assert r_node.hostname == "host"
+        assert r_node.process_count == 1
+        assert r_node.thread_count == 4
         assert r_node.cpu_percent == 45.0
         assert r_node.memory_bytes == 8_000_000_000
         assert "host:100-0" in r_node.workers
         r_worker = r_node.workers["host:100-0"]
         assert r_worker.pid == 100
         assert r_worker.queues == ("default", "high")
-        assert r_worker.cpu_percent == 33.0
 
 
 @pytest.mark.integration
@@ -779,13 +780,13 @@ class TestWorkerTelemetryRedis:
                 thread_count=2,
                 task_count=5,
                 tasks_per_minute=10.0,
-                cpu_percent=20.0,
-                memory_bytes=50_000_000,
                 sampled_at=sampled_at,
             )
             node = NodeTelemetry(
                 hostname="testhost",
                 queues=("default",),
+                process_count=1,
+                thread_count=2,
                 cpu_percent=30.0,
                 memory_percent=40.0,
                 memory_bytes=4_000_000_000,
@@ -805,10 +806,11 @@ class TestWorkerTelemetryRedis:
             r_node = received.nodes["testhost"]
             assert r_node.hostname == "testhost"
             assert r_node.cpu_percent == 30.0
+            assert r_node.process_count == 1
+            assert r_node.thread_count == 2
             assert "testhost:200-0" in r_node.workers
             r_worker = r_node.workers["testhost:200-0"]
             assert r_worker.pid == 200
-            assert r_worker.cpu_percent == 20.0
             assert "default" in received.queues
         finally:
             backend.close()

--- a/tests/backends/test_redis.py
+++ b/tests/backends/test_redis.py
@@ -749,13 +749,13 @@ class TestWorkerTelemetrySerialization:
 
 
 @pytest.mark.integration
-class TestWorkerTelemetryPubSub:
-    """Integration tests for worker telemetry PUB/SUB over real Redis."""
+class TestWorkerTelemetryRedis:
+    """Integration tests for worker telemetry storage over real Redis."""
 
-    def test_publish_and_subscribe_roundtrip(self):
-        """publish_worker_telemetry sends, worker_telemetry receives."""
+    def test_publish_and_read_roundtrip(self):
+        """publish_worker_telemetry stores, worker_telemetry reads it back."""
         backend = RedisTaskBackend(
-            "worker_telemetry_pubsub_test",
+            "worker_telemetry_store_test",
             {
                 "QUEUES": ["default"],
                 "REDIS_URL": "redis://localhost:6379/0",
@@ -800,8 +800,6 @@ class TestWorkerTelemetryPubSub:
             )
             backend.publish_worker_telemetry(snapshot)
 
-            # Small delay for pub/sub propagation
-            time.sleep(0.1)
             received = backend.worker_telemetry()
             assert "testhost" in received.nodes
             r_node = received.nodes["testhost"]
@@ -815,8 +813,8 @@ class TestWorkerTelemetryPubSub:
         finally:
             backend.close()
 
-    def test_worker_telemetry_empty_when_no_messages(self):
-        """worker_telemetry returns an empty snapshot when no messages are waiting."""
+    def test_worker_telemetry_empty_when_no_workers(self):
+        """worker_telemetry returns an empty snapshot when no workers reported."""
         backend = RedisTaskBackend(
             "worker_telemetry_empty_test",
             {

--- a/tests/backends/test_redis.py
+++ b/tests/backends/test_redis.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import datetime
 import logging
@@ -15,9 +16,13 @@ from django.utils import timezone
 from tests.testapp.tasks import boom, compute_workload, echo
 from threadmill.backends.base import (
     BackendTelemetry,
+    NodeTelemetry,
     QueueCounts,
     QueueRates,
     QueueStats,
+    ThreadmillTaskBackend,
+    WorkerProcessTelemetry,
+    WorkerTelemetry,
 )
 from threadmill.backends.redis import RedisBroker, RedisTaskBackend  # noqa: E402
 
@@ -753,8 +758,8 @@ class TestWorkerTelemetrySerialization:
 class TestWorkerTelemetryRedis:
     """Integration tests for worker telemetry storage over real Redis."""
 
-    def test_publish_and_read_roundtrip(self):
-        """publish_worker_telemetry stores, worker_telemetry reads it back."""
+    async def test_publish_and_read_roundtrip(self):
+        """publish_worker_telemetry publishes, subscribe_worker_telemetry reads it back."""
         backend = RedisTaskBackend(
             "worker_telemetry_store_test",
             {
@@ -766,12 +771,6 @@ class TestWorkerTelemetryRedis:
             },
         )
         try:
-            from threadmill.backends.base import (
-                NodeTelemetry,
-                WorkerProcessTelemetry,
-                WorkerTelemetry,
-            )
-
             sampled_at = datetime.datetime.now(tz=datetime.UTC)
             worker = WorkerProcessTelemetry(
                 name="testhost:200-0",
@@ -799,9 +798,17 @@ class TestWorkerTelemetryRedis:
                 queues={"default": ("testhost",)},
                 sampled_at=sampled_at,
             )
+
+            async def _collect():
+                async for received in backend.subscribe_worker_telemetry():
+                    return received
+
+            task = asyncio.ensure_future(_collect())
+            # Give the pub/sub subscription a moment to establish.
+            await asyncio.sleep(0.1)
             backend.publish_worker_telemetry(snapshot)
 
-            received = backend.worker_telemetry()
+            received = await asyncio.wait_for(task, timeout=5.0)
             assert "testhost" in received.nodes
             r_node = received.nodes["testhost"]
             assert r_node.hostname == "testhost"
@@ -815,21 +822,14 @@ class TestWorkerTelemetryRedis:
         finally:
             backend.close()
 
-    def test_worker_telemetry_empty_when_no_workers(self):
-        """worker_telemetry returns an empty snapshot when no workers reported."""
-        backend = RedisTaskBackend(
-            "worker_telemetry_empty_test",
-            {
-                "QUEUES": ["default"],
-                "REDIS_URL": "redis://localhost:6379/0",
-                "OPTIONS": {
-                    "result_ttl": datetime.timedelta(seconds=60),
-                },
-            },
-        )
-        try:
-            snapshot = backend.worker_telemetry()
-            assert snapshot.nodes == {}
-            assert snapshot.queues == {}
-        finally:
-            backend.close()
+    async def test_worker_telemetry_empty_when_no_workers(self):
+        """The default subscribe_worker_telemetry yields an empty snapshot."""
+
+        class _StubBackend(ThreadmillTaskBackend):
+            def enqueue(self, *args, **kwargs):  # pragma: no cover
+                raise NotImplementedError
+
+        backend = _StubBackend(alias="test", params={})
+        received = await backend.subscribe_worker_telemetry().__anext__()
+        assert received.nodes == {}
+        assert received.queues == {}

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -253,6 +253,29 @@ class TestWorkerProcess:
         worker.shutdown_requested.set()
         assert worker.shutdown_requested.is_set()
 
+    def test_run__starts_and_stops_telemetry_sampler(self):
+        """run() creates, starts, and stops a TelemetrySampler."""
+        from unittest.mock import MagicMock, patch
+
+        sampler = MagicMock()
+        worker = _make_worker()
+        # Patch TelemetrySampler so run() uses our mock instead of the real one.
+        # Patch WorkerThread so consumer threads exit immediately.
+        with (
+            patch("threadmill.executor.TelemetrySampler", return_value=sampler),
+            patch(
+                "threadmill.executor.WorkerThread",
+                side_effect=lambda **kwargs: MagicMock(
+                    start=lambda: None,
+                    join=lambda timeout=None: None,
+                ),
+            ),
+        ):
+            worker.run()
+        sampler.start.assert_called_once()
+        sampler.stop.assert_called_once()
+        assert worker.telemetry_sampler is sampler
+
 
 class TestWorkerThread:
     """Tests for the WorkerThread class."""

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -21,16 +21,22 @@ from textual.widgets._data_table import RowKey
 from tests.testapp.tasks import echo
 from threadmill.backends.base import (
     BackendTelemetry,
+    NodeTelemetry,
     QueueCounts,
     QueueRates,
     QueueStats,
     ThreadmillTaskBackend,
+    WorkerProcessTelemetry,
+    WorkerTelemetry,
 )
 from threadmill.inspector.app import (
     InspectorApp,
     QueueList,
+    SelectionTree,
     TaskDetail,
     TaskList,
+    WorkerGraphs,
+    WorkerTreeNode,
     si_prefix,
 )
 
@@ -46,6 +52,9 @@ class FailingBackend(ThreadmillTaskBackend):
 
     def telemetry(self, *, interval=None):
         raise RuntimeError("telemetry failed")
+
+    def worker_telemetry(self):
+        raise RuntimeError("worker_telemetry failed")
 
 
 def _failed_result() -> TaskResult:
@@ -511,3 +520,334 @@ class TestInspectorApp:
             await pilot.pause()
             await pilot.pause()
             assert table.row_count == before - 1
+
+
+def _make_worker_telemetry(
+    *,
+    hostname: str = "node-1",
+    worker_name: str = "node-1:1234-0",
+    queue_name: str = "default",
+) -> WorkerTelemetry:
+    """Build a WorkerTelemetry snapshot for inspector tests."""
+    now = datetime.datetime.now(tz=datetime.UTC)
+    worker = WorkerProcessTelemetry(
+        name=worker_name,
+        pid=1234,
+        queues=(queue_name,),
+        thread_count=2,
+        task_count=10,
+        tasks_per_minute=30.0,
+        cpu_percent=12.5,
+        memory_bytes=100_000_000,
+        sampled_at=now,
+    )
+    node = NodeTelemetry(
+        hostname=hostname,
+        queues=(queue_name,),
+        cpu_percent=45.0,
+        memory_percent=60.0,
+        memory_bytes=8_000_000_000,
+        tasks_per_minute=30.0,
+        workers={worker_name: worker},
+        sampled_at=now,
+    )
+    return WorkerTelemetry(
+        nodes={hostname: node},
+        queues={queue_name: (hostname,)},
+        sampled_at=now,
+    )
+
+
+class TestWorkerView:
+    """Tests for the worker view (selection tree, graphs, toggle)."""
+
+    async def test_selection_tree_builds_from_telemetry(self):
+        """The selection tree renders Queue -> Node -> Worker from telemetry."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tree = app.query_one("#selection-tree", SelectionTree)
+            snapshot = _make_worker_telemetry()
+            tree.telemetry = snapshot
+            await pilot.pause()
+            root = tree.root
+            assert len(root.children) == 1
+            queue_node = root.children[0]
+            assert queue_node.data.kind == "queue"
+            assert queue_node.data.queue_name == "default"
+            assert len(queue_node.children) == 1
+            host_node = queue_node.children[0]
+            assert host_node.data.kind == "node"
+            assert host_node.data.hostname == "node-1"
+            assert len(host_node.children) == 1
+            worker_node = host_node.children[0]
+            assert worker_node.data.kind == "worker"
+            assert worker_node.data.worker_name == "node-1:1234-0"
+
+    async def test_toggle_view_shows_worker_widgets(self):
+        """Pressing 'v' shows the selection tree and worker graphs."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app.worker_view_enabled is False
+            assert app.query_one("#queue-list", QueueList).display
+            assert not app.query_one("#selection-tree", SelectionTree).display
+            await pilot.press("v")
+            await pilot.pause()
+            assert app.worker_view_enabled is True
+            assert not app.query_one("#queue-list", QueueList).display
+            assert app.query_one("#selection-tree", SelectionTree).display
+            assert app.query_one("#worker-graphs", WorkerGraphs).display
+
+    async def test_toggle_view_back_to_queue(self):
+        """Pressing 'v' again returns to the queue view."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("v")
+            await pilot.pause()
+            assert app.worker_view_enabled is True
+            await pilot.press("v")
+            await pilot.pause()
+            assert app.worker_view_enabled is False
+            assert app.query_one("#queue-list", QueueList).display
+
+    async def test_worker_graphs_update_on_selection(self):
+        """Selecting a worker node feeds the worker graphs."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tree = app.query_one("#selection-tree", SelectionTree)
+            graphs = app.query_one("#worker-graphs", WorkerGraphs)
+            snapshot = _make_worker_telemetry()
+            tree.telemetry = snapshot
+            await pilot.pause()
+            # Select the worker node
+            root = tree.root
+            queue_node = root.children[0]
+            host_node = queue_node.children[0]
+            worker_node = host_node.children[0]
+            tree.select_node(worker_node)
+            tree.action_select_cursor()
+            await pilot.pause()
+            assert graphs.selection is not None
+            assert graphs.selection.kind == "worker"
+            assert graphs.selection.worker_name == "node-1:1234-0"
+
+    async def test_worker_graphs_append_history_on_telemetry(self):
+        """Worker graphs accumulate data points as telemetry arrives."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            graphs = app.query_one("#worker-graphs", WorkerGraphs)
+            snapshot = _make_worker_telemetry()
+            # Set selection first
+            node_data = WorkerTreeNode(
+                kind="node",
+                label="node-1",
+                hostname="node-1",
+            )
+            graphs.selection = node_data
+            await pilot.pause()
+            graphs.telemetry = snapshot
+            await pilot.pause()
+            assert len(graphs._cpu_history) == 1
+            assert graphs._cpu_history[0] == 45.0
+
+    async def test_refresh_telemetry_fetches_worker_telemetry(self):
+        """_refresh_telemetry populates the worker_telemetry reactive."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._refresh_telemetry()
+            await pilot.pause()
+            # The default backend returns an empty snapshot
+            assert app.worker_telemetry is not None
+            assert app.worker_telemetry.nodes == {}
+
+    async def test_selection_tree_preserves_cursor_on_update(self):
+        """The tree restores the cursor to the same node after a telemetry update."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tree = app.query_one("#selection-tree", SelectionTree)
+            tree.telemetry = _make_worker_telemetry()
+            await pilot.pause()
+            # Move cursor to the worker node
+            root = tree.root
+            queue_node = root.children[0]
+            host_node = queue_node.children[0]
+            worker_node = host_node.children[0]
+            tree.select_node(worker_node)
+            await pilot.pause()
+            # Send a new telemetry snapshot
+            tree.telemetry = _make_worker_telemetry()
+            await pilot.pause()
+            assert tree.cursor_node is not None
+            assert tree.cursor_node.data.kind == "worker"
+
+    async def test_worker_graphs_show_worker_selection(self):
+        """Selecting a worker node shows worker-level metrics in the graphs."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tree = app.query_one("#selection-tree", SelectionTree)
+            graphs = app.query_one("#worker-graphs", WorkerGraphs)
+            snapshot = _make_worker_telemetry()
+            tree.telemetry = snapshot
+            await pilot.pause()
+            root = tree.root
+            queue_node = root.children[0]
+            host_node = queue_node.children[0]
+            worker_node = host_node.children[0]
+            tree.select_node(worker_node)
+            await pilot.pause()
+            graphs.selection = worker_node.data
+            graphs.telemetry = snapshot
+            await pilot.pause()
+            assert len(graphs._cpu_history) == 1
+            assert graphs._cpu_history[0] == 12.5
+
+    async def test_selection_tree_resets_cursor_when_node_gone(self):
+        """_find_node_by_data returns None when the previous node is gone."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tree = app.query_one("#selection-tree", SelectionTree)
+            tree.telemetry = _make_worker_telemetry()
+            await pilot.pause()
+            # Capture the worker data, then build a different snapshot
+            root = tree.root
+            queue_node = root.children[0]
+            host_node = queue_node.children[0]
+            worker_node = host_node.children[0]
+            old_data = worker_node.data
+            # New snapshot with a different worker name
+            tree.telemetry = _make_worker_telemetry(worker_name="node-1:9999-0")
+            await pilot.pause()
+            # The old worker data is not in the new tree
+            result = SelectionTree._find_node_by_data(tree.root, old_data)
+            assert result is None
+
+    async def test_worker_graphs_reset_on_selection_change(self):
+        """Changing the selection resets the graph histories."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            graphs = app.query_one("#worker-graphs", WorkerGraphs)
+            node_data = WorkerTreeNode(kind="node", label="node-1", hostname="node-1")
+            graphs.selection = node_data
+            await pilot.pause()
+            graphs.telemetry = _make_worker_telemetry()
+            await pilot.pause()
+            assert len(graphs._cpu_history) == 1
+            # Change selection — watch_selection resets histories, then
+            # _refresh_graphs appends from the current telemetry.
+            graphs.selection = WorkerTreeNode(
+                kind="worker",
+                label="node-1:1234-0",
+                hostname="node-1",
+                worker_name="node-1:1234-0",
+            )
+            await pilot.pause()
+            # After reset + refresh, the worker's CPU value is present.
+            assert len(graphs._cpu_history) == 1
+            assert graphs._cpu_history[0] == 12.5
+
+    async def test_worker_graphs_ignore_missing_node(self):
+        """Graphs do nothing when the selected node is not in the telemetry."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            graphs = app.query_one("#worker-graphs", WorkerGraphs)
+            graphs.selection = WorkerTreeNode(
+                kind="node", label="ghost", hostname="ghost"
+            )
+            await pilot.pause()
+            graphs.telemetry = _make_worker_telemetry()
+            await pilot.pause()
+            assert len(graphs._cpu_history) == 0
+
+    async def test_refresh_telemetry_logs_on_worker_telemetry_error(self):
+        """_refresh_telemetry logs when worker_telemetry raises."""
+        backend = FailingBackend(alias="default", params={})
+        app = InspectorApp(backend=backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # The exception is caught and logged; the app does not crash.
+            assert app.worker_telemetry is not None
+
+    async def test_selection_tree_skips_queue_with_missing_node(self):
+        """The tree skips a queue whose hostname is not in the nodes dict."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tree = app.query_one("#selection-tree", SelectionTree)
+            now = datetime.datetime.now(tz=datetime.UTC)
+            snapshot = WorkerTelemetry(
+                nodes={},
+                queues={"default": ("ghost-host",)},
+                sampled_at=now,
+            )
+            tree.telemetry = snapshot
+            await pilot.pause()
+            root = tree.root
+            assert len(root.children) == 1
+            queue_node = root.children[0]
+            assert len(queue_node.children) == 0
+
+    async def test_worker_graphs_ignore_missing_worker(self):
+        """Graphs skip when the selected worker is not in the node's workers."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            graphs = app.query_one("#worker-graphs", WorkerGraphs)
+            # Select a worker that doesn't exist in the telemetry
+            graphs.selection = WorkerTreeNode(
+                kind="worker",
+                label="ghost-worker",
+                hostname="node-1",
+                worker_name="ghost-worker",
+            )
+            await pilot.pause()
+            graphs.telemetry = _make_worker_telemetry()
+            await pilot.pause()
+            assert len(graphs._cpu_history) == 0
+
+    async def test_worker_graphs_ignore_unknown_selection_kind(self):
+        """Graphs do nothing when the selection kind is neither node nor worker."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            graphs = app.query_one("#worker-graphs", WorkerGraphs)
+            # Use a valid hostname so we pass the node lookup, but an
+            # unknown kind so the if/elif chain falls through to else.
+            graphs.selection = WorkerTreeNode(
+                kind="queue",
+                label="default",
+                queue_name="default",
+                hostname="node-1",
+            )
+            await pilot.pause()
+            graphs.telemetry = _make_worker_telemetry()
+            await pilot.pause()
+            assert len(graphs._cpu_history) == 0
+
+    async def test_worker_graphs_handles_unmounted_widgets(self):
+        """_refresh_graphs logs when Sparkline widgets are not yet mounted."""
+        from unittest.mock import patch
+
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            graphs = app.query_one("#worker-graphs", WorkerGraphs)
+            graphs.selection = WorkerTreeNode(
+                kind="node", label="node-1", hostname="node-1"
+            )
+            await pilot.pause()
+            # Patch query_one to raise as if widgets are not mounted.
+            with patch.object(graphs, "query_one", side_effect=Exception("no widget")):
+                graphs.telemetry = _make_worker_telemetry()
+                await pilot.pause()
+            # Histories are populated even though the graph redraw failed.
+            assert len(graphs._cpu_history) == 1

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -608,6 +608,23 @@ class TestWorkerView:
             assert app.worker_view_enabled is False
             assert app.query_one("#queue-list", QueueList).display
 
+    async def test_toggle_binding_label_updates(self):
+        """The 'v' binding description changes with the current view."""
+        from textual.binding import Binding
+
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app.worker_view_enabled is False
+            binding = app._bindings.key_to_bindings["v"][0]
+            assert isinstance(binding, Binding)
+            assert binding.description == "Toggle Worker View"
+            await pilot.press("v")
+            await pilot.pause()
+            assert app.worker_view_enabled is True
+            binding = app._bindings.key_to_bindings["v"][0]
+            assert binding.description == "Toggle Queue View"
+
     async def test_worker_graphs_update_on_selection(self):
         """Selecting a node feeds the worker graphs."""
         app = InspectorApp(backend=default_task_backend, auto_refresh=False)
@@ -644,10 +661,13 @@ class TestWorkerView:
             )
             graphs.selection = node_data
             await pilot.pause()
+            # History is pre-filled with zeros at the fixed window size.
+            assert len(graphs._cpu_history) == graphs.GRAPH_HISTORY_SIZE
             graphs.telemetry = snapshot
             await pilot.pause()
-            assert len(graphs._cpu_history) == 1
-            assert graphs._cpu_history[0] == 45.0
+            # The last entry is the new sample; length stays fixed.
+            assert len(graphs._cpu_history) == graphs.GRAPH_HISTORY_SIZE
+            assert graphs._cpu_history[-1] == 45.0
 
     async def test_refresh_telemetry_fetches_worker_telemetry(self):
         """_refresh_telemetry populates the worker_telemetry reactive."""
@@ -698,8 +718,8 @@ class TestWorkerView:
             graphs.selection = host_node.data
             graphs.telemetry = snapshot
             await pilot.pause()
-            assert len(graphs._cpu_history) == 1
-            assert graphs._cpu_history[0] == 45.0
+            assert len(graphs._cpu_history) == graphs.GRAPH_HISTORY_SIZE
+            assert graphs._cpu_history[-1] == 45.0
 
     async def test_selection_tree_resets_cursor_when_node_gone(self):
         """_find_node_by_data returns None when the previous node is gone."""
@@ -732,7 +752,7 @@ class TestWorkerView:
             await pilot.pause()
             graphs.telemetry = _make_worker_telemetry()
             await pilot.pause()
-            assert len(graphs._cpu_history) == 1
+            assert len(graphs._cpu_history) == graphs.GRAPH_HISTORY_SIZE
             # Change selection to a different node — watch_selection resets
             # histories, then _refresh_graphs appends from the current telemetry.
             graphs.selection = WorkerTreeNode(
@@ -741,8 +761,10 @@ class TestWorkerView:
                 hostname="node-2",
             )
             await pilot.pause()
-            # After reset, histories are empty because node-2 is not in telemetry.
-            assert len(graphs._cpu_history) == 0
+            # After reset, histories are pre-filled with zeros; node-2 is not
+            # in telemetry, so no new sample is appended.
+            assert len(graphs._cpu_history) == graphs.GRAPH_HISTORY_SIZE
+            assert graphs._cpu_history[-1] == 0.0
 
     async def test_worker_graphs_ignore_missing_node(self):
         """Graphs do nothing when the selected node is not in the telemetry."""
@@ -756,7 +778,8 @@ class TestWorkerView:
             await pilot.pause()
             graphs.telemetry = _make_worker_telemetry()
             await pilot.pause()
-            assert len(graphs._cpu_history) == 0
+            assert len(graphs._cpu_history) == graphs.GRAPH_HISTORY_SIZE
+            assert graphs._cpu_history[-1] == 0.0
 
     async def test_refresh_telemetry_logs_on_worker_telemetry_error(self):
         """_refresh_telemetry logs when worker_telemetry raises."""
@@ -802,7 +825,8 @@ class TestWorkerView:
             await pilot.pause()
             graphs.telemetry = _make_worker_telemetry()
             await pilot.pause()
-            assert len(graphs._cpu_history) == 0
+            assert len(graphs._cpu_history) == graphs.GRAPH_HISTORY_SIZE
+            assert graphs._cpu_history[-1] == 0.0
 
     async def test_worker_graphs_handles_unmounted_widgets(self):
         """_refresh_graphs logs when Sparkline widgets are not yet mounted."""
@@ -821,4 +845,4 @@ class TestWorkerView:
                 graphs.telemetry = _make_worker_telemetry()
                 await pilot.pause()
             # Histories are populated even though the graph redraw failed.
-            assert len(graphs._cpu_history) == 1
+            assert len(graphs._cpu_history) == graphs.GRAPH_HISTORY_SIZE

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -537,13 +537,13 @@ def _make_worker_telemetry(
         thread_count=2,
         task_count=10,
         tasks_per_minute=30.0,
-        cpu_percent=12.5,
-        memory_bytes=100_000_000,
         sampled_at=now,
     )
     node = NodeTelemetry(
         hostname=hostname,
         queues=(queue_name,),
+        process_count=1,
+        thread_count=2,
         cpu_percent=45.0,
         memory_percent=60.0,
         memory_bytes=8_000_000_000,
@@ -562,7 +562,7 @@ class TestWorkerView:
     """Tests for the worker view (selection tree, graphs, toggle)."""
 
     async def test_selection_tree_builds_from_telemetry(self):
-        """The selection tree renders Queue -> Node -> Worker from telemetry."""
+        """The selection tree renders Queue -> Node from telemetry."""
         app = InspectorApp(backend=default_task_backend, auto_refresh=False)
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -579,10 +579,6 @@ class TestWorkerView:
             host_node = queue_node.children[0]
             assert host_node.data.kind == "node"
             assert host_node.data.hostname == "node-1"
-            assert len(host_node.children) == 1
-            worker_node = host_node.children[0]
-            assert worker_node.data.kind == "worker"
-            assert worker_node.data.worker_name == "node-1:1234-0"
 
     async def test_toggle_view_shows_worker_widgets(self):
         """Pressing 'v' shows the selection tree and worker graphs."""
@@ -613,7 +609,7 @@ class TestWorkerView:
             assert app.query_one("#queue-list", QueueList).display
 
     async def test_worker_graphs_update_on_selection(self):
-        """Selecting a worker node feeds the worker graphs."""
+        """Selecting a node feeds the worker graphs."""
         app = InspectorApp(backend=default_task_backend, auto_refresh=False)
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -622,17 +618,16 @@ class TestWorkerView:
             snapshot = _make_worker_telemetry()
             tree.telemetry = snapshot
             await pilot.pause()
-            # Select the worker node
+            # Select the node
             root = tree.root
             queue_node = root.children[0]
             host_node = queue_node.children[0]
-            worker_node = host_node.children[0]
-            tree.select_node(worker_node)
+            tree.select_node(host_node)
             tree.action_select_cursor()
             await pilot.pause()
             assert graphs.selection is not None
-            assert graphs.selection.kind == "worker"
-            assert graphs.selection.worker_name == "node-1:1234-0"
+            assert graphs.selection.kind == "node"
+            assert graphs.selection.hostname == "node-1"
 
     async def test_worker_graphs_append_history_on_telemetry(self):
         """Worker graphs accumulate data points as telemetry arrives."""
@@ -673,21 +668,20 @@ class TestWorkerView:
             tree = app.query_one("#selection-tree", SelectionTree)
             tree.telemetry = _make_worker_telemetry()
             await pilot.pause()
-            # Move cursor to the worker node
+            # Move cursor to the node
             root = tree.root
             queue_node = root.children[0]
             host_node = queue_node.children[0]
-            worker_node = host_node.children[0]
-            tree.select_node(worker_node)
+            tree.select_node(host_node)
             await pilot.pause()
             # Send a new telemetry snapshot
             tree.telemetry = _make_worker_telemetry()
             await pilot.pause()
             assert tree.cursor_node is not None
-            assert tree.cursor_node.data.kind == "worker"
+            assert tree.cursor_node.data.kind == "node"
 
-    async def test_worker_graphs_show_worker_selection(self):
-        """Selecting a worker node shows worker-level metrics in the graphs."""
+    async def test_worker_graphs_show_node_selection(self):
+        """Selecting a node shows node-level metrics in the graphs."""
         app = InspectorApp(backend=default_task_backend, auto_refresh=False)
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -699,14 +693,13 @@ class TestWorkerView:
             root = tree.root
             queue_node = root.children[0]
             host_node = queue_node.children[0]
-            worker_node = host_node.children[0]
-            tree.select_node(worker_node)
+            tree.select_node(host_node)
             await pilot.pause()
-            graphs.selection = worker_node.data
+            graphs.selection = host_node.data
             graphs.telemetry = snapshot
             await pilot.pause()
             assert len(graphs._cpu_history) == 1
-            assert graphs._cpu_history[0] == 12.5
+            assert graphs._cpu_history[0] == 45.0
 
     async def test_selection_tree_resets_cursor_when_node_gone(self):
         """_find_node_by_data returns None when the previous node is gone."""
@@ -716,16 +709,15 @@ class TestWorkerView:
             tree = app.query_one("#selection-tree", SelectionTree)
             tree.telemetry = _make_worker_telemetry()
             await pilot.pause()
-            # Capture the worker data, then build a different snapshot
+            # Capture the node data, then build a different snapshot
             root = tree.root
             queue_node = root.children[0]
             host_node = queue_node.children[0]
-            worker_node = host_node.children[0]
-            old_data = worker_node.data
-            # New snapshot with a different worker name
-            tree.telemetry = _make_worker_telemetry(worker_name="node-1:9999-0")
+            old_data = host_node.data
+            # New snapshot with a different hostname
+            tree.telemetry = _make_worker_telemetry(hostname="node-2")
             await pilot.pause()
-            # The old worker data is not in the new tree
+            # The old node data is not in the new tree
             result = SelectionTree._find_node_by_data(tree.root, old_data)
             assert result is None
 
@@ -741,18 +733,16 @@ class TestWorkerView:
             graphs.telemetry = _make_worker_telemetry()
             await pilot.pause()
             assert len(graphs._cpu_history) == 1
-            # Change selection — watch_selection resets histories, then
-            # _refresh_graphs appends from the current telemetry.
+            # Change selection to a different node — watch_selection resets
+            # histories, then _refresh_graphs appends from the current telemetry.
             graphs.selection = WorkerTreeNode(
-                kind="worker",
-                label="node-1:1234-0",
-                hostname="node-1",
-                worker_name="node-1:1234-0",
+                kind="node",
+                label="node-2",
+                hostname="node-2",
             )
             await pilot.pause()
-            # After reset + refresh, the worker's CPU value is present.
-            assert len(graphs._cpu_history) == 1
-            assert graphs._cpu_history[0] == 12.5
+            # After reset, histories are empty because node-2 is not in telemetry.
+            assert len(graphs._cpu_history) == 0
 
     async def test_worker_graphs_ignore_missing_node(self):
         """Graphs do nothing when the selected node is not in the telemetry."""
@@ -796,32 +786,13 @@ class TestWorkerView:
             queue_node = root.children[0]
             assert len(queue_node.children) == 0
 
-    async def test_worker_graphs_ignore_missing_worker(self):
-        """Graphs skip when the selected worker is not in the node's workers."""
+    async def test_worker_graphs_ignore_non_node_selection(self):
+        """Graphs skip when the selection kind is not 'node'."""
         app = InspectorApp(backend=default_task_backend, auto_refresh=False)
         async with app.run_test() as pilot:
             await pilot.pause()
             graphs = app.query_one("#worker-graphs", WorkerGraphs)
-            # Select a worker that doesn't exist in the telemetry
-            graphs.selection = WorkerTreeNode(
-                kind="worker",
-                label="ghost-worker",
-                hostname="node-1",
-                worker_name="ghost-worker",
-            )
-            await pilot.pause()
-            graphs.telemetry = _make_worker_telemetry()
-            await pilot.pause()
-            assert len(graphs._cpu_history) == 0
-
-    async def test_worker_graphs_ignore_unknown_selection_kind(self):
-        """Graphs do nothing when the selection kind is neither node nor worker."""
-        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            graphs = app.query_one("#worker-graphs", WorkerGraphs)
-            # Use a valid hostname so we pass the node lookup, but an
-            # unknown kind so the if/elif chain falls through to else.
+            # Use a valid hostname but a queue kind so _refresh_graphs returns early
             graphs.selection = WorkerTreeNode(
                 kind="queue",
                 label="default",

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -647,7 +647,7 @@ class TestWorkerView:
             assert graphs.selection.hostname == "node-1"
 
     async def test_worker_graphs_append_history_on_telemetry(self):
-        """Worker graphs accumulate data points as telemetry arrives."""
+        """Worker graphs accumulate data points when a sample tick fires."""
         app = InspectorApp(backend=default_task_backend, auto_refresh=False)
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -664,6 +664,10 @@ class TestWorkerView:
             # History is pre-filled with zeros at the fixed window size.
             assert len(graphs._cpu_history) == graphs.GRAPH_HISTORY_SIZE
             graphs.telemetry = snapshot
+            await pilot.pause()
+            # A telemetry update alone does not append a sample — only the
+            # fixed-interval timer does.  Simulate a timer tick.
+            graphs._refresh_graphs()
             await pilot.pause()
             # The last entry is the new sample; length stays fixed.
             assert len(graphs._cpu_history) == graphs.GRAPH_HISTORY_SIZE
@@ -717,6 +721,8 @@ class TestWorkerView:
             await pilot.pause()
             graphs.selection = host_node.data
             graphs.telemetry = snapshot
+            await pilot.pause()
+            graphs._refresh_graphs()
             await pilot.pause()
             assert len(graphs._cpu_history) == graphs.GRAPH_HISTORY_SIZE
             assert graphs._cpu_history[-1] == 45.0
@@ -846,3 +852,175 @@ class TestWorkerView:
                 await pilot.pause()
             # Histories are populated even though the graph redraw failed.
             assert len(graphs._cpu_history) == graphs.GRAPH_HISTORY_SIZE
+
+
+class _StubBackend(ThreadmillTaskBackend):
+    """Backend double that yields a fixed worker telemetry snapshot."""
+
+    def enqueue(self, task, args, kwargs):
+        raise NotImplementedError
+
+    def peek(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def telemetry(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def worker_telemetry(self):
+        raise NotImplementedError
+
+    async def subscribe_worker_telemetry(self):
+        yield _make_worker_telemetry()
+
+
+class _ExplodingBackend(_StubBackend):
+    """Backend whose pub/sub subscription raises immediately."""
+
+    async def subscribe_worker_telemetry(self):
+        raise RuntimeError("subscribe failed")
+        yield  # pragma: no cover
+
+
+def _make_node(
+    *,
+    hostname: str = "node-1",
+    pid: int = 100,
+    worker_name: str | None = None,
+    queue_name: str = "default",
+    thread_count: int = 2,
+    sampled_at: datetime.datetime | None = None,
+) -> NodeTelemetry:
+    """Build a single-worker NodeTelemetry for cache-population tests."""
+    now = sampled_at or datetime.datetime.now(tz=datetime.UTC)
+    name = worker_name or f"{hostname}:{pid}-0"
+    worker = WorkerProcessTelemetry(
+        name=name,
+        pid=pid,
+        queues=(queue_name,),
+        thread_count=thread_count,
+        task_count=10,
+        tasks_per_minute=30.0,
+        sampled_at=now,
+    )
+    return NodeTelemetry(
+        hostname=hostname,
+        queues=(queue_name,),
+        process_count=1,
+        thread_count=thread_count,
+        cpu_percent=45.0,
+        memory_percent=60.0,
+        memory_bytes=8_000_000_000,
+        tasks_per_minute=30.0,
+        workers={name: worker},
+        sampled_at=now,
+    )
+
+
+def _snapshot_from_node(node: NodeTelemetry) -> WorkerTelemetry:
+    """Wrap a single node into a WorkerTelemetry snapshot for merge tests."""
+    return WorkerTelemetry(
+        nodes={node.hostname: node},
+        queues=dict.fromkeys(node.queues, (node.hostname,)),
+        sampled_at=node.sampled_at,
+    )
+
+
+class TestWorkerTelemetrySubscription:
+    """Tests for the pub/sub merge/prune/build helper methods."""
+
+    def test_merge_worker_telemetry_caches_by_hostname_pid(self):
+        """_merge_worker_telemetry caches nodes keyed by (hostname, pid)."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        snapshot = _make_worker_telemetry()
+        app._merge_worker_telemetry(snapshot)
+        assert ("node-1", 1234) in app._telemetry_cache
+        node = app._telemetry_cache[("node-1", 1234)]
+        assert node.hostname == "node-1"
+
+    def test_merge_worker_telemetry_multiple_workers_same_host(self):
+        """Two workers on the same host produce two cache entries keyed by pid."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        app._merge_worker_telemetry(
+            _snapshot_from_node(_make_node(pid=100, queue_name="default"))
+        )
+        app._merge_worker_telemetry(
+            _snapshot_from_node(_make_node(pid=200, queue_name="celery"))
+        )
+        assert len(app._telemetry_cache) == 2
+        assert ("node-1", 100) in app._telemetry_cache
+        assert ("node-1", 200) in app._telemetry_cache
+
+    def test_prune_stale_telemetry_removes_old_entries(self):
+        """_prune_stale_telemetry drops entries older than the TTL."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        snapshot = _make_worker_telemetry()
+        # Force the sampled_at into the past, beyond the TTL window.
+        old = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(seconds=20)
+        stale_node = dataclasses.replace(
+            next(iter(snapshot.nodes.values())), sampled_at=old
+        )
+        app._telemetry_cache[("node-1", 1234)] = stale_node
+        app._prune_stale_telemetry(10)
+        assert ("node-1", 1234) not in app._telemetry_cache
+
+    def test_prune_stale_telemetry_keeps_fresh_entries(self):
+        """_prune_stale_telemetry retains entries within the TTL window."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        snapshot = _make_worker_telemetry()
+        app._merge_worker_telemetry(snapshot)
+        app._prune_stale_telemetry(10)
+        assert ("node-1", 1234) in app._telemetry_cache
+
+    def test_build_merged_telemetry_merges_same_host(self):
+        """_build_merged_telemetry merges workers on the same hostname."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        # Two per-worker snapshots on the same host but different queues/pids.
+        app._merge_worker_telemetry(
+            _snapshot_from_node(
+                _make_node(pid=100, queue_name="default", thread_count=2)
+            )
+        )
+        app._merge_worker_telemetry(
+            _snapshot_from_node(
+                _make_node(pid=200, queue_name="celery", thread_count=3)
+            )
+        )
+        merged = app._build_merged_telemetry()
+        assert len(merged.nodes) == 1
+        node = merged.nodes["node-1"]
+        assert len(node.workers) == 2
+        # process_count and thread_count are summed across the two entries.
+        assert node.process_count == 2
+        assert node.thread_count == 5
+        # Queues from both snapshots are collected.
+        assert set(node.queues) == {"default", "celery"}
+        assert set(merged.queues) == {"default", "celery"}
+
+    def test_build_merged_telemetry_empty_cache(self):
+        """_build_merged_telemetry returns an empty snapshot from an empty cache."""
+        app = InspectorApp(backend=default_task_backend, auto_refresh=False)
+        merged = app._build_merged_telemetry()
+        assert merged.nodes == {}
+        assert merged.queues == {}
+
+    async def test_subscribe_worker_telemetry_updates_reactive(self):
+        """_subscribe_worker_telemetry merges snapshots into worker_telemetry."""
+        backend = _StubBackend(alias="default", params={})
+        app = InspectorApp(backend=backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await app._subscribe_worker_telemetry()
+            await pilot.pause()
+            assert app.worker_telemetry is not None
+            assert "node-1" in app.worker_telemetry.nodes
+
+    async def test_subscribe_worker_telemetry_logs_on_error(self):
+        """A failing subscription is caught and logged without crashing."""
+        backend = _ExplodingBackend(alias="default", params={})
+        app = InspectorApp(backend=backend, auto_refresh=False)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await app._subscribe_worker_telemetry()
+            await pilot.pause()
+            # worker_telemetry is initialized in on_mount and never cleared.
+            assert app.worker_telemetry is not None

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -34,13 +34,13 @@ def _make_worker_telemetry(
         thread_count=2,
         task_count=10,
         tasks_per_minute=30.0,
-        cpu_percent=12.5,
-        memory_bytes=100_000_000,
         sampled_at=sampled_at,
     )
     node = NodeTelemetry(
         hostname=hostname,
         queues=("default",),
+        process_count=1,
+        thread_count=2,
         cpu_percent=45.0,
         memory_percent=60.0,
         memory_bytes=8_000_000_000,
@@ -68,8 +68,6 @@ class TestWorkerTelemetryDataTypes:
             thread_count=4,
             task_count=50,
             tasks_per_minute=12.0,
-            cpu_percent=33.0,
-            memory_bytes=200_000_000,
             sampled_at=now,
         )
         assert worker.name == "host:100-0"
@@ -78,8 +76,6 @@ class TestWorkerTelemetryDataTypes:
         assert worker.thread_count == 4
         assert worker.task_count == 50
         assert worker.tasks_per_minute == 12.0
-        assert worker.cpu_percent == 33.0
-        assert worker.memory_bytes == 200_000_000
         assert worker.sampled_at == now
 
     def test_node_telemetry_fields(self):
@@ -92,13 +88,13 @@ class TestWorkerTelemetryDataTypes:
             thread_count=1,
             task_count=0,
             tasks_per_minute=0.0,
-            cpu_percent=5.0,
-            memory_bytes=50_000_000,
             sampled_at=now,
         )
         node = NodeTelemetry(
             hostname="host",
             queues=("default",),
+            process_count=1,
+            thread_count=1,
             cpu_percent=20.0,
             memory_percent=50.0,
             memory_bytes=4_000_000_000,
@@ -107,6 +103,8 @@ class TestWorkerTelemetryDataTypes:
             sampled_at=now,
         )
         assert node.hostname == "host"
+        assert node.process_count == 1
+        assert node.thread_count == 1
         assert node.cpu_percent == 20.0
         assert node.memory_percent == 50.0
         assert node.memory_bytes == 4_000_000_000
@@ -122,13 +120,13 @@ class TestWorkerTelemetryDataTypes:
             thread_count=1,
             task_count=0,
             tasks_per_minute=0.0,
-            cpu_percent=0.0,
-            memory_bytes=0,
             sampled_at=now,
         )
         node = NodeTelemetry(
             hostname="h",
             queues=("default",),
+            process_count=1,
+            thread_count=1,
             cpu_percent=0.0,
             memory_percent=0.0,
             memory_bytes=0,
@@ -193,11 +191,6 @@ class TestTelemetrySampler:
 
     def test_sample_returns_worker_telemetry(self):
         """sample() builds a WorkerTelemetry with node and worker data."""
-        fake_process = MagicMock()
-        fake_process.cpu_percent.return_value = 15.0
-        fake_process.memory_info.return_value = MagicMock(rss=123_456_789)
-        fake_process.pid = 100
-
         fake_vmem = MagicMock()
         fake_vmem.percent = 55.0
         fake_vmem.total = 8_000_000_000
@@ -212,7 +205,7 @@ class TestTelemetrySampler:
             patch("threadmill.telemetry.psutil") as fake_psutil,
             patch("threadmill.telemetry.socket.gethostname", return_value="testhost"),
         ):
-            fake_psutil.Process.return_value = fake_process
+            fake_psutil.Process.return_value = MagicMock(pid=100)
             fake_psutil.cpu_percent.return_value = 42.0
             fake_psutil.virtual_memory.return_value = fake_vmem
 
@@ -224,11 +217,11 @@ class TestTelemetrySampler:
         assert node.cpu_percent == 42.0
         assert node.memory_percent == 55.0
         assert node.memory_bytes == 8_000_000_000
+        assert node.process_count == 1
+        assert node.thread_count == 2
         assert "testhost:100-0" in node.workers
         worker = node.workers["testhost:100-0"]
         assert worker.pid == 100
-        assert worker.cpu_percent == 15.0
-        assert worker.memory_bytes == 123_456_789
         assert worker.task_count == 5
         assert "default" in snapshot.queues
         assert "testhost" in snapshot.queues["default"]
@@ -291,11 +284,6 @@ class TestTelemetrySampler:
             worker_process=worker_process,
         )
 
-        fake_process = MagicMock()
-        fake_process.cpu_percent.return_value = 5.0
-        fake_process.memory_info.return_value = MagicMock(rss=1000)
-        fake_process.pid = 100
-
         fake_vmem = MagicMock()
         fake_vmem.percent = 40.0
         fake_vmem.total = 4_000_000_000
@@ -304,7 +292,7 @@ class TestTelemetrySampler:
             patch("threadmill.telemetry.psutil") as fake_psutil,
             patch("threadmill.telemetry.socket.gethostname", return_value="h"),
         ):
-            fake_psutil.Process.return_value = fake_process
+            fake_psutil.Process.return_value = MagicMock(pid=100)
             fake_psutil.cpu_percent.return_value = 10.0
             fake_psutil.virtual_memory.return_value = fake_vmem
             sampler._publish_one_sample()
@@ -325,11 +313,6 @@ class TestTelemetrySampler:
             interval_seconds=0.01,
         )
 
-        fake_process = MagicMock()
-        fake_process.cpu_percent.return_value = 5.0
-        fake_process.memory_info.return_value = MagicMock(rss=1000)
-        fake_process.pid = 100
-
         fake_vmem = MagicMock()
         fake_vmem.percent = 40.0
         fake_vmem.total = 4_000_000_000
@@ -338,7 +321,7 @@ class TestTelemetrySampler:
             patch("threadmill.telemetry.psutil") as fake_psutil,
             patch("threadmill.telemetry.socket.gethostname", return_value="h"),
         ):
-            fake_psutil.Process.return_value = fake_process
+            fake_psutil.Process.return_value = MagicMock(pid=100)
             fake_psutil.cpu_percent.return_value = 10.0
             fake_psutil.virtual_memory.return_value = fake_vmem
             with caplog.at_level(logging.ERROR):

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,351 @@
+"""Tests for worker telemetry data types and the psutil sampler."""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from threadmill.backends.base import (
+    NodeTelemetry,
+    ThreadmillTaskBackend,
+    WorkerProcessTelemetry,
+    WorkerTelemetry,
+)
+from threadmill.telemetry import TelemetrySampler
+
+utc = datetime.UTC
+
+
+def _make_worker_telemetry(
+    *,
+    hostname: str = "node-1",
+    worker_name: str = "node-1:1234-0",
+    sampled_at: datetime.datetime | None = None,
+) -> WorkerTelemetry:
+    """Build a minimal WorkerTelemetry snapshot for tests."""
+    sampled_at = sampled_at or datetime.datetime.now(tz=utc)
+    worker = WorkerProcessTelemetry(
+        name=worker_name,
+        pid=1234,
+        queues=("default",),
+        thread_count=2,
+        task_count=10,
+        tasks_per_minute=30.0,
+        cpu_percent=12.5,
+        memory_bytes=100_000_000,
+        sampled_at=sampled_at,
+    )
+    node = NodeTelemetry(
+        hostname=hostname,
+        queues=("default",),
+        cpu_percent=45.0,
+        memory_percent=60.0,
+        memory_bytes=8_000_000_000,
+        tasks_per_minute=30.0,
+        workers={worker_name: worker},
+        sampled_at=sampled_at,
+    )
+    return WorkerTelemetry(
+        nodes={hostname: node},
+        queues={"default": (hostname,)},
+        sampled_at=sampled_at,
+    )
+
+
+class TestWorkerTelemetryDataTypes:
+    """Tests for the telemetry dataclasses defined in backends/base.py."""
+
+    def test_worker_process_telemetry_fields(self):
+        """WorkerProcessTelemetry stores all expected fields."""
+        now = datetime.datetime.now(tz=utc)
+        worker = WorkerProcessTelemetry(
+            name="host:100-0",
+            pid=100,
+            queues=("default",),
+            thread_count=4,
+            task_count=50,
+            tasks_per_minute=12.0,
+            cpu_percent=33.0,
+            memory_bytes=200_000_000,
+            sampled_at=now,
+        )
+        assert worker.name == "host:100-0"
+        assert worker.pid == 100
+        assert worker.queues == ("default",)
+        assert worker.thread_count == 4
+        assert worker.task_count == 50
+        assert worker.tasks_per_minute == 12.0
+        assert worker.cpu_percent == 33.0
+        assert worker.memory_bytes == 200_000_000
+        assert worker.sampled_at == now
+
+    def test_node_telemetry_fields(self):
+        """NodeTelemetry stores workers dict and node-level metrics."""
+        now = datetime.datetime.now(tz=utc)
+        worker = WorkerProcessTelemetry(
+            name="host:100-0",
+            pid=100,
+            queues=("default",),
+            thread_count=1,
+            task_count=0,
+            tasks_per_minute=0.0,
+            cpu_percent=5.0,
+            memory_bytes=50_000_000,
+            sampled_at=now,
+        )
+        node = NodeTelemetry(
+            hostname="host",
+            queues=("default",),
+            cpu_percent=20.0,
+            memory_percent=50.0,
+            memory_bytes=4_000_000_000,
+            tasks_per_minute=0.0,
+            workers={"host:100-0": worker},
+            sampled_at=now,
+        )
+        assert node.hostname == "host"
+        assert node.cpu_percent == 20.0
+        assert node.memory_percent == 50.0
+        assert node.memory_bytes == 4_000_000_000
+        assert "host:100-0" in node.workers
+
+    def test_worker_telemetry_queues_and_nodes(self):
+        """WorkerTelemetry maps queues to hostnames and nodes to NodeTelemetry."""
+        now = datetime.datetime.now(tz=utc)
+        worker = WorkerProcessTelemetry(
+            name="h:1-0",
+            pid=1,
+            queues=("default",),
+            thread_count=1,
+            task_count=0,
+            tasks_per_minute=0.0,
+            cpu_percent=0.0,
+            memory_bytes=0,
+            sampled_at=now,
+        )
+        node = NodeTelemetry(
+            hostname="h",
+            queues=("default",),
+            cpu_percent=0.0,
+            memory_percent=0.0,
+            memory_bytes=0,
+            tasks_per_minute=0.0,
+            workers={"h:1-0": worker},
+            sampled_at=now,
+        )
+        telemetry = WorkerTelemetry(
+            nodes={"h": node},
+            queues={"default": ("h",)},
+            sampled_at=now,
+        )
+        assert "h" in telemetry.nodes
+        assert telemetry.queues["default"] == ("h",)
+        assert telemetry.sampled_at == now
+
+
+class TestBaseBackendHooks:
+    """Tests for the default backend hooks."""
+
+    class _ConcreteBackend(ThreadmillTaskBackend):
+        """Minimal concrete backend for hook testing."""
+
+        def enqueue(self, task, args, kwargs):
+            raise NotImplementedError
+
+    def test_publish_worker_telemetry_is_noop(self):
+        """The base publish hook does nothing and does not raise."""
+        backend = self._ConcreteBackend(alias="test", params={})
+        backend.publish_worker_telemetry(_make_worker_telemetry())
+
+    def test_worker_telemetry_returns_empty_snapshot(self):
+        """The base worker_telemetry hook returns an empty but valid snapshot."""
+        backend = self._ConcreteBackend(alias="test", params={})
+        snapshot = backend.worker_telemetry()
+        assert snapshot.nodes == {}
+        assert snapshot.queues == {}
+        assert snapshot.sampled_at is not None
+
+
+class TestTelemetrySampler:
+    """Tests for the TelemetrySampler with stubbed psutil."""
+
+    def _make_worker_process(self):
+        """Build a fake worker process with the attributes the sampler reads."""
+        proc = MagicMock()
+        proc.name = "testhost:100-0"
+        proc.queues = ("default",)
+        proc.thread_count = 2
+        proc.task_count = 5
+        proc.pid = 100
+        return proc
+
+    def test_is_available_when_psutil_imported(self):
+        """is_available is True when psutil is importable."""
+        sampler = TelemetrySampler(
+            backend=MagicMock(),
+            worker_process=self._make_worker_process(),
+        )
+        # psutil is installed in the test environment
+        assert sampler.is_available is True
+
+    def test_sample_returns_worker_telemetry(self):
+        """sample() builds a WorkerTelemetry with node and worker data."""
+        fake_process = MagicMock()
+        fake_process.cpu_percent.return_value = 15.0
+        fake_process.memory_info.return_value = MagicMock(rss=123_456_789)
+        fake_process.pid = 100
+
+        fake_vmem = MagicMock()
+        fake_vmem.percent = 55.0
+        fake_vmem.total = 8_000_000_000
+
+        worker_process = self._make_worker_process()
+        sampler = TelemetrySampler(
+            backend=MagicMock(),
+            worker_process=worker_process,
+        )
+
+        with (
+            patch("threadmill.telemetry.psutil") as fake_psutil,
+            patch("threadmill.telemetry.socket.gethostname", return_value="testhost"),
+        ):
+            fake_psutil.Process.return_value = fake_process
+            fake_psutil.cpu_percent.return_value = 42.0
+            fake_psutil.virtual_memory.return_value = fake_vmem
+
+            snapshot = sampler.sample()
+
+        assert "testhost" in snapshot.nodes
+        node = snapshot.nodes["testhost"]
+        assert node.hostname == "testhost"
+        assert node.cpu_percent == 42.0
+        assert node.memory_percent == 55.0
+        assert node.memory_bytes == 8_000_000_000
+        assert "testhost:100-0" in node.workers
+        worker = node.workers["testhost:100-0"]
+        assert worker.pid == 100
+        assert worker.cpu_percent == 15.0
+        assert worker.memory_bytes == 123_456_789
+        assert worker.task_count == 5
+        assert "default" in snapshot.queues
+        assert "testhost" in snapshot.queues["default"]
+
+    def test_tasks_per_minute_first_call_returns_zero(self):
+        """The first throughput sample returns 0 (no previous baseline)."""
+        sampler = TelemetrySampler(
+            backend=MagicMock(),
+            worker_process=self._make_worker_process(),
+            clock=lambda: 100.0,
+        )
+        assert sampler._tasks_per_minute(10, 100.0) == 0.0
+
+    def test_tasks_per_minute_computes_delta(self):
+        """Throughput is (delta_tasks / elapsed_seconds) * 60."""
+        sampler = TelemetrySampler(
+            backend=MagicMock(),
+            worker_process=self._make_worker_process(),
+            clock=lambda: 100.0,
+        )
+        sampler._tasks_per_minute(10, 100.0)
+        rate = sampler._tasks_per_minute(25, 130.0)
+        assert rate == pytest.approx(30.0)
+
+    def test_tasks_per_minute_zero_elapsed_returns_zero(self):
+        """When elapsed time is zero, throughput returns 0 to avoid division by zero."""
+        sampler = TelemetrySampler(
+            backend=MagicMock(),
+            worker_process=self._make_worker_process(),
+            clock=lambda: 100.0,
+        )
+        sampler._tasks_per_minute(10, 100.0)
+        rate = sampler._tasks_per_minute(20, 100.0)
+        assert rate == 0.0
+
+    def test_start_without_psutil_is_noop(self):
+        """start() does nothing when psutil is not available."""
+        sampler = TelemetrySampler(
+            backend=MagicMock(),
+            worker_process=self._make_worker_process(),
+        )
+        with patch("threadmill.telemetry.psutil", None):
+            sampler.start()
+        assert sampler._thread is None
+
+    def test_stop_without_start_is_noop(self):
+        """stop() does not raise when the sampler was never started."""
+        sampler = TelemetrySampler(
+            backend=MagicMock(),
+            worker_process=self._make_worker_process(),
+        )
+        sampler.stop()
+
+    def test_publish_one_sample_calls_backend(self):
+        """_publish_one_sample calls backend.publish_worker_telemetry."""
+        backend = MagicMock()
+        worker_process = self._make_worker_process()
+        sampler = TelemetrySampler(
+            backend=backend,
+            worker_process=worker_process,
+        )
+
+        fake_process = MagicMock()
+        fake_process.cpu_percent.return_value = 5.0
+        fake_process.memory_info.return_value = MagicMock(rss=1000)
+        fake_process.pid = 100
+
+        fake_vmem = MagicMock()
+        fake_vmem.percent = 40.0
+        fake_vmem.total = 4_000_000_000
+
+        with (
+            patch("threadmill.telemetry.psutil") as fake_psutil,
+            patch("threadmill.telemetry.socket.gethostname", return_value="h"),
+        ):
+            fake_psutil.Process.return_value = fake_process
+            fake_psutil.cpu_percent.return_value = 10.0
+            fake_psutil.virtual_memory.return_value = fake_vmem
+            sampler._publish_one_sample()
+
+        backend.publish_worker_telemetry.assert_called_once()
+        snapshot = backend.publish_worker_telemetry.call_args.args[0]
+        assert isinstance(snapshot, WorkerTelemetry)
+        assert "h" in snapshot.nodes
+
+    def test_run_logs_exception_on_sample_failure(self, caplog):
+        """_run logs an exception when _publish_one_sample raises."""
+        backend = MagicMock()
+        backend.publish_worker_telemetry.side_effect = RuntimeError("boom")
+        worker_process = self._make_worker_process()
+        sampler = TelemetrySampler(
+            backend=backend,
+            worker_process=worker_process,
+            interval_seconds=0.01,
+        )
+
+        fake_process = MagicMock()
+        fake_process.cpu_percent.return_value = 5.0
+        fake_process.memory_info.return_value = MagicMock(rss=1000)
+        fake_process.pid = 100
+
+        fake_vmem = MagicMock()
+        fake_vmem.percent = 40.0
+        fake_vmem.total = 4_000_000_000
+
+        with (
+            patch("threadmill.telemetry.psutil") as fake_psutil,
+            patch("threadmill.telemetry.socket.gethostname", return_value="h"),
+        ):
+            fake_psutil.Process.return_value = fake_process
+            fake_psutil.cpu_percent.return_value = 10.0
+            fake_psutil.virtual_memory.return_value = fake_vmem
+            with caplog.at_level(logging.ERROR):
+                sampler.start()
+                import time as _time
+
+                _time.sleep(0.1)
+                sampler.stop()
+
+        assert "Failed to sample worker telemetry" in caplog.text

--- a/threadmill/backends/base.py
+++ b/threadmill/backends/base.py
@@ -71,6 +71,50 @@ class BackendTelemetry:
     queues: dict[str, QueueStats]
 
 
+@dataclasses.dataclass(kw_only=True, slots=True)
+class WorkerProcessTelemetry:
+    """Telemetry for a single worker process (one OS process)."""
+
+    name: str
+    pid: int
+    queues: tuple[str, ...]
+    thread_count: int
+    task_count: int
+    tasks_per_minute: float
+    cpu_percent: float
+    memory_bytes: int
+    sampled_at: datetime.datetime
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class NodeTelemetry:
+    """Telemetry for a single node (host) running worker processes."""
+
+    hostname: str
+    queues: tuple[str, ...]
+    cpu_percent: float
+    memory_percent: float
+    memory_bytes: int
+    tasks_per_minute: float
+    workers: dict[str, WorkerProcessTelemetry]
+    sampled_at: datetime.datetime
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class WorkerTelemetry:
+    """Snapshot of worker pool health across a backend's queues and nodes.
+
+    ``nodes`` is keyed by hostname; each node carries its own CPU/mem sample
+    plus a dict of worker-process samples keyed by worker name. ``queues``
+    maps each queue name to the hostnames listening on it, so the inspector
+    can render a Queue -> Node -> Worker selection tree.
+    """
+
+    nodes: dict[str, NodeTelemetry]
+    queues: dict[str, tuple[str, ...]]
+    sampled_at: datetime.datetime
+
+
 class Broker(threading.Thread):
     """Backend maintenance thread launched by the task executor."""
 
@@ -218,3 +262,22 @@ class ThreadmillTaskBackend(BaseTaskBackend, ABC):
             interval: The time window for rolling rates.
         """
         raise NotImplementedError
+
+    def publish_worker_telemetry(self, telemetry: WorkerTelemetry) -> None:
+        """Publish a worker-pool telemetry snapshot to subscribers.
+
+        Backends without a pub/sub transport implement this as a no-op so the
+        worker command still runs without worker telemetry.
+        """
+
+    def worker_telemetry(self) -> WorkerTelemetry:
+        """Return the latest worker-pool telemetry snapshot, or an empty one.
+
+        Backends without a pub/sub transport return an empty snapshot so the
+        inspector can render the worker view without raising.
+        """
+        return WorkerTelemetry(
+            nodes={},
+            queues={},
+            sampled_at=datetime.datetime.now(tz=datetime.UTC),
+        )

--- a/threadmill/backends/base.py
+++ b/threadmill/backends/base.py
@@ -264,16 +264,16 @@ class ThreadmillTaskBackend(BaseTaskBackend, ABC):
         raise NotImplementedError
 
     def publish_worker_telemetry(self, telemetry: WorkerTelemetry) -> None:
-        """Publish a worker-pool telemetry snapshot to subscribers.
+        """Publish a worker-pool telemetry snapshot to a shared store.
 
-        Backends without a pub/sub transport implement this as a no-op so the
+        Backends without a shared store implement this as a no-op so the
         worker command still runs without worker telemetry.
         """
 
     def worker_telemetry(self) -> WorkerTelemetry:
         """Return the latest worker-pool telemetry snapshot, or an empty one.
 
-        Backends without a pub/sub transport return an empty snapshot so the
+        Backends without a shared store return an empty snapshot so the
         inspector can render the worker view without raising.
         """
         return WorkerTelemetry(

--- a/threadmill/backends/base.py
+++ b/threadmill/backends/base.py
@@ -73,7 +73,11 @@ class BackendTelemetry:
 
 @dataclasses.dataclass(kw_only=True, slots=True)
 class WorkerProcessTelemetry:
-    """Telemetry for a single worker process (one OS process)."""
+    """Telemetry for a single worker process (one OS process).
+
+    CPU and memory are tracked at the node level only, since per-process
+    memory accounting is noisy and per-process CPU adds too much clutter.
+    """
 
     name: str
     pid: int
@@ -81,17 +85,22 @@ class WorkerProcessTelemetry:
     thread_count: int
     task_count: int
     tasks_per_minute: float
-    cpu_percent: float
-    memory_bytes: int
     sampled_at: datetime.datetime
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
 class NodeTelemetry:
-    """Telemetry for a single node (host) running worker processes."""
+    """Telemetry for a single node (host) running worker processes.
+
+    ``process_count`` and ``thread_count`` aggregate across all worker
+    processes on this node.  CPU and memory are sampled at the system level
+    via ``psutil``.
+    """
 
     hostname: str
     queues: tuple[str, ...]
+    process_count: int
+    thread_count: int
     cpu_percent: float
     memory_percent: float
     memory_bytes: int
@@ -104,10 +113,10 @@ class NodeTelemetry:
 class WorkerTelemetry:
     """Snapshot of worker pool health across a backend's queues and nodes.
 
-    ``nodes`` is keyed by hostname; each node carries its own CPU/mem sample
-    plus a dict of worker-process samples keyed by worker name. ``queues``
-    maps each queue name to the hostnames listening on it, so the inspector
-    can render a Queue -> Node -> Worker selection tree.
+    ``nodes`` is keyed by hostname; each node carries system-level CPU/mem
+    plus a dict of worker-process entries (name, pid, threads, throughput).
+    ``queues`` maps each queue name to the hostnames listening on it, so the
+    inspector can render a Queue -> Node selection tree.
     """
 
     nodes: dict[str, NodeTelemetry]

--- a/threadmill/backends/base.py
+++ b/threadmill/backends/base.py
@@ -5,6 +5,7 @@ import dataclasses
 import datetime
 import json
 import threading
+import typing
 from abc import ABC
 
 import django
@@ -286,6 +287,20 @@ class ThreadmillTaskBackend(BaseTaskBackend, ABC):
         inspector can render the worker view without raising.
         """
         return WorkerTelemetry(
+            nodes={},
+            queues={},
+            sampled_at=datetime.datetime.now(tz=datetime.UTC),
+        )
+
+    async def subscribe_worker_telemetry(self) -> typing.AsyncIterator[WorkerTelemetry]:
+        """Yield worker telemetry snapshots as they arrive.
+
+        Backends with pub/sub capability override this to maintain a
+        persistent subscription.  The default implementation yields a
+        single empty snapshot and stops, so non-Redis backends still
+        compile and the inspector can fall back to polling.
+        """
+        yield WorkerTelemetry(
             nodes={},
             queues={},
             sampled_at=datetime.datetime.now(tz=datetime.UTC),

--- a/threadmill/backends/redis.py
+++ b/threadmill/backends/redis.py
@@ -492,6 +492,8 @@ class RedisTaskBackend(ThreadmillTaskBackend):
                             hostname: NodeTelemetry(
                                 hostname=node.hostname,
                                 queues=node.queues,
+                                process_count=node.process_count,
+                                thread_count=node.thread_count,
                                 cpu_percent=node.cpu_percent,
                                 memory_percent=node.memory_percent,
                                 memory_bytes=node.memory_bytes,
@@ -536,6 +538,8 @@ class RedisTaskBackend(ThreadmillTaskBackend):
                     nodes[hostname].queues = tuple(
                         sorted(set(nodes[hostname].queues) | set(node.queues))
                     )
+                    nodes[hostname].process_count += node.process_count
+                    nodes[hostname].thread_count += node.thread_count
                 else:
                     nodes[hostname] = node
                 for queue_name in node.queues:
@@ -576,6 +580,8 @@ def _serialize_node(node: NodeTelemetry) -> dict:
     return {
         "hostname": node.hostname,
         "queues": list(node.queues),
+        "process_count": node.process_count,
+        "thread_count": node.thread_count,
         "cpu_percent": node.cpu_percent,
         "memory_percent": node.memory_percent,
         "memory_bytes": node.memory_bytes,
@@ -596,8 +602,6 @@ def _serialize_worker(worker: WorkerProcessTelemetry) -> dict:
         "thread_count": worker.thread_count,
         "task_count": worker.task_count,
         "tasks_per_minute": worker.tasks_per_minute,
-        "cpu_percent": worker.cpu_percent,
-        "memory_bytes": worker.memory_bytes,
         "sampled_at": worker.sampled_at.isoformat(),
     }
 
@@ -626,6 +630,8 @@ def _deserialize_node(data: dict) -> NodeTelemetry:
     return NodeTelemetry(
         hostname=data["hostname"],
         queues=tuple(data.get("queues", [])),
+        process_count=data["process_count"],
+        thread_count=data["thread_count"],
         cpu_percent=data["cpu_percent"],
         memory_percent=data["memory_percent"],
         memory_bytes=data["memory_bytes"],
@@ -644,7 +650,5 @@ def _deserialize_worker(data: dict) -> WorkerProcessTelemetry:
         thread_count=data["thread_count"],
         task_count=data["task_count"],
         tasks_per_minute=data["tasks_per_minute"],
-        cpu_percent=data["cpu_percent"],
-        memory_bytes=data["memory_bytes"],
         sampled_at=datetime.datetime.fromisoformat(data["sampled_at"]),
     )

--- a/threadmill/backends/redis.py
+++ b/threadmill/backends/redis.py
@@ -139,7 +139,9 @@ class RedisTaskBackend(ThreadmillTaskBackend):
     SUCCESSFUL_RESULTS_KEY = "{prefix}:results:{queue_name}:successful"
     FAILED_RESULTS_KEY = "{prefix}:results:{queue_name}:failed"
     INGRESS_KEY = "{prefix}:ingress:{queue_name}:events"
-    WORKER_TELEMETRY_CHANNEL = "{prefix}:worker-telemetry"
+    WORKER_TELEMETRY_KEY = "{prefix}:worker-telemetry:{hostname}:{pid}"
+    WORKER_TELEMETRY_PATTERN = "{prefix}:worker-telemetry:*"
+    WORKER_TELEMETRY_TTL = 10  # seconds before stale keys expire
 
     ACQUIRE_SCRIPT = _load_lua("acquire")
     """Pop the next task from a priority queue and move it directly to the running set."""
@@ -471,41 +473,75 @@ class RedisTaskBackend(ThreadmillTaskBackend):
         return BackendTelemetry(queues=queues)
 
     def publish_worker_telemetry(self, telemetry: WorkerTelemetry) -> None:
-        """Publish a worker telemetry snapshot to the pub/sub channel."""
-        channel = self.WORKER_TELEMETRY_CHANNEL.format(prefix=self.key_prefix)
-        self.client.publish(channel, _serialize_worker_telemetry(telemetry))
+        """Store a worker telemetry snapshot in Redis with a short TTL.
+
+        Each worker process writes its own key so the inspector can scan
+        and merge all active snapshots.  Keys expire automatically when a
+        worker stops reporting.
+        """
+        for hostname, node in telemetry.nodes.items():
+            for worker_name, worker in node.workers.items():
+                key = self.WORKER_TELEMETRY_KEY.format(
+                    prefix=self.key_prefix,
+                    hostname=hostname,
+                    pid=worker.pid,
+                )
+                payload = _serialize_worker_telemetry(
+                    WorkerTelemetry(
+                        nodes={
+                            hostname: NodeTelemetry(
+                                hostname=node.hostname,
+                                queues=node.queues,
+                                cpu_percent=node.cpu_percent,
+                                memory_percent=node.memory_percent,
+                                memory_bytes=node.memory_bytes,
+                                tasks_per_minute=node.tasks_per_minute,
+                                workers={worker_name: worker},
+                                sampled_at=node.sampled_at,
+                            )
+                        },
+                        queues=dict.fromkeys(node.queues, (hostname,)),
+                        sampled_at=telemetry.sampled_at,
+                    )
+                )
+                self.client.set(key, payload, ex=self.WORKER_TELEMETRY_TTL)
 
     def worker_telemetry(self) -> WorkerTelemetry:
-        """Drain pending worker telemetry messages and merge them by node.
+        """Read and merge all worker telemetry snapshots from Redis.
 
-        Returns an empty snapshot when no messages are waiting so the inspector
-        can render the worker view before any workers have reported.
+        Returns an empty snapshot when no workers have reported so the
+        inspector can render the worker view before any workers are running.
         """
-        channel = self.WORKER_TELEMETRY_CHANNEL.format(prefix=self.key_prefix)
-        pubsub = self.client.pubsub(ignore_subscribe_messages=True)
-        pubsub.subscribe(channel)
+        pattern = self.WORKER_TELEMETRY_PATTERN.format(prefix=self.key_prefix)
+        keys = list(self.client.scan_iter(match=pattern))
+        if not keys:
+            return WorkerTelemetry(
+                nodes={},
+                queues={},
+                sampled_at=datetime.datetime.now(tz=datetime.UTC),
+            )
         nodes: dict[str, NodeTelemetry] = {}
         queues: dict[str, set[str]] = {}
         sampled_at = datetime.datetime.now(tz=datetime.UTC)
-        try:
-            while True:
-                message = pubsub.get_message(timeout=0.01)
-                if message is None:
-                    break
-                if message.get("type") != "message":
-                    continue
-                data = message.get("data")
-                if not data:
-                    continue
-                payload = data.decode() if isinstance(data, bytes) else data
-                snapshot = _deserialize_worker_telemetry(payload)
-                nodes.update(snapshot.nodes)
-                for queue_name, hostnames in snapshot.queues.items():
-                    queues.setdefault(queue_name, set()).update(hostnames)
-                if snapshot.sampled_at > sampled_at:
-                    sampled_at = snapshot.sampled_at
-        finally:
-            pubsub.close()
+        for key in keys:
+            payload = self.client.get(key)
+            if not payload:
+                continue
+            if isinstance(payload, bytes):
+                payload = payload.decode()
+            snapshot = _deserialize_worker_telemetry(payload)
+            for hostname, node in snapshot.nodes.items():
+                if hostname in nodes:
+                    nodes[hostname].workers.update(node.workers)
+                    nodes[hostname].queues = tuple(
+                        sorted(set(nodes[hostname].queues) | set(node.queues))
+                    )
+                else:
+                    nodes[hostname] = node
+                for queue_name in node.queues:
+                    queues.setdefault(queue_name, set()).add(hostname)
+            if snapshot.sampled_at > sampled_at:
+                sampled_at = snapshot.sampled_at
         return WorkerTelemetry(
             nodes=nodes,
             queues={name: tuple(sorted(hosts)) for name, hosts in queues.items()},

--- a/threadmill/backends/redis.py
+++ b/threadmill/backends/redis.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import logging
 import queue
 import time
@@ -11,6 +12,7 @@ from collections.abc import Generator, Sequence
 from pathlib import Path
 
 import redis
+from django.core.serializers.json import DjangoJSONEncoder
 from django.tasks import DEFAULT_TASK_QUEUE_NAME, TaskResult, TaskResultStatus
 from django.tasks.exceptions import TaskResultDoesNotExist
 from django.tasks.signals import task_enqueued
@@ -19,10 +21,13 @@ from django.utils import timezone
 from threadmill.backends.base import (
     BackendTelemetry,
     Broker,
+    NodeTelemetry,
     QueueCounts,
     QueueRates,
     QueueStats,
     ThreadmillTaskBackend,
+    WorkerProcessTelemetry,
+    WorkerTelemetry,
 )
 
 logger = logging.getLogger(__name__)
@@ -134,6 +139,7 @@ class RedisTaskBackend(ThreadmillTaskBackend):
     SUCCESSFUL_RESULTS_KEY = "{prefix}:results:{queue_name}:successful"
     FAILED_RESULTS_KEY = "{prefix}:results:{queue_name}:failed"
     INGRESS_KEY = "{prefix}:ingress:{queue_name}:events"
+    WORKER_TELEMETRY_CHANNEL = "{prefix}:worker-telemetry"
 
     ACQUIRE_SCRIPT = _load_lua("acquire")
     """Pop the next task from a priority queue and move it directly to the running set."""
@@ -464,6 +470,145 @@ class RedisTaskBackend(ThreadmillTaskBackend):
             )
         return BackendTelemetry(queues=queues)
 
+    def publish_worker_telemetry(self, telemetry: WorkerTelemetry) -> None:
+        """Publish a worker telemetry snapshot to the pub/sub channel."""
+        channel = self.WORKER_TELEMETRY_CHANNEL.format(prefix=self.key_prefix)
+        self.client.publish(channel, _serialize_worker_telemetry(telemetry))
+
+    def worker_telemetry(self) -> WorkerTelemetry:
+        """Drain pending worker telemetry messages and merge them by node.
+
+        Returns an empty snapshot when no messages are waiting so the inspector
+        can render the worker view before any workers have reported.
+        """
+        channel = self.WORKER_TELEMETRY_CHANNEL.format(prefix=self.key_prefix)
+        pubsub = self.client.pubsub(ignore_subscribe_messages=True)
+        pubsub.subscribe(channel)
+        nodes: dict[str, NodeTelemetry] = {}
+        queues: dict[str, set[str]] = {}
+        sampled_at = datetime.datetime.now(tz=datetime.UTC)
+        try:
+            while True:
+                message = pubsub.get_message(timeout=0.01)
+                if message is None:
+                    break
+                if message.get("type") != "message":
+                    continue
+                data = message.get("data")
+                if not data:
+                    continue
+                payload = data.decode() if isinstance(data, bytes) else data
+                snapshot = _deserialize_worker_telemetry(payload)
+                nodes.update(snapshot.nodes)
+                for queue_name, hostnames in snapshot.queues.items():
+                    queues.setdefault(queue_name, set()).update(hostnames)
+                if snapshot.sampled_at > sampled_at:
+                    sampled_at = snapshot.sampled_at
+        finally:
+            pubsub.close()
+        return WorkerTelemetry(
+            nodes=nodes,
+            queues={name: tuple(sorted(hosts)) for name, hosts in queues.items()},
+            sampled_at=sampled_at,
+        )
+
     def close(self) -> None:
         """Close the Redis connection."""
         self.client.close()
+
+
+def _serialize_worker_telemetry(telemetry: WorkerTelemetry) -> str:
+    """Serialize a WorkerTelemetry snapshot to a JSON string."""
+    return json.dumps(
+        {
+            "nodes": {
+                hostname: _serialize_node(node)
+                for hostname, node in telemetry.nodes.items()
+            },
+            "queues": {
+                queue_name: list(hostnames)
+                for queue_name, hostnames in telemetry.queues.items()
+            },
+            "sampled_at": telemetry.sampled_at.isoformat(),
+        },
+        cls=DjangoJSONEncoder,
+    )
+
+
+def _serialize_node(node: NodeTelemetry) -> dict:
+    """Serialize a NodeTelemetry to a JSON-ready dict."""
+    return {
+        "hostname": node.hostname,
+        "queues": list(node.queues),
+        "cpu_percent": node.cpu_percent,
+        "memory_percent": node.memory_percent,
+        "memory_bytes": node.memory_bytes,
+        "tasks_per_minute": node.tasks_per_minute,
+        "workers": {
+            name: _serialize_worker(worker) for name, worker in node.workers.items()
+        },
+        "sampled_at": node.sampled_at.isoformat(),
+    }
+
+
+def _serialize_worker(worker: WorkerProcessTelemetry) -> dict:
+    """Serialize a WorkerProcessTelemetry to a JSON-ready dict."""
+    return {
+        "name": worker.name,
+        "pid": worker.pid,
+        "queues": list(worker.queues),
+        "thread_count": worker.thread_count,
+        "task_count": worker.task_count,
+        "tasks_per_minute": worker.tasks_per_minute,
+        "cpu_percent": worker.cpu_percent,
+        "memory_bytes": worker.memory_bytes,
+        "sampled_at": worker.sampled_at.isoformat(),
+    }
+
+
+def _deserialize_worker_telemetry(payload: str) -> WorkerTelemetry:
+    """Deserialize a JSON string into a WorkerTelemetry snapshot."""
+    data = json.loads(payload)
+    nodes = {
+        hostname: _deserialize_node(node_data)
+        for hostname, node_data in data.get("nodes", {}).items()
+    }
+    queues = {
+        queue_name: tuple(hostnames)
+        for queue_name, hostnames in data.get("queues", {}).items()
+    }
+    sampled_at = datetime.datetime.fromisoformat(data["sampled_at"])
+    return WorkerTelemetry(nodes=nodes, queues=queues, sampled_at=sampled_at)
+
+
+def _deserialize_node(data: dict) -> NodeTelemetry:
+    """Deserialize a JSON dict into a NodeTelemetry."""
+    workers = {
+        name: _deserialize_worker(worker_data)
+        for name, worker_data in data.get("workers", {}).items()
+    }
+    return NodeTelemetry(
+        hostname=data["hostname"],
+        queues=tuple(data.get("queues", [])),
+        cpu_percent=data["cpu_percent"],
+        memory_percent=data["memory_percent"],
+        memory_bytes=data["memory_bytes"],
+        tasks_per_minute=data["tasks_per_minute"],
+        workers=workers,
+        sampled_at=datetime.datetime.fromisoformat(data["sampled_at"]),
+    )
+
+
+def _deserialize_worker(data: dict) -> WorkerProcessTelemetry:
+    """Deserialize a JSON dict into a WorkerProcessTelemetry."""
+    return WorkerProcessTelemetry(
+        name=data["name"],
+        pid=data["pid"],
+        queues=tuple(data.get("queues", [])),
+        thread_count=data["thread_count"],
+        task_count=data["task_count"],
+        tasks_per_minute=data["tasks_per_minute"],
+        cpu_percent=data["cpu_percent"],
+        memory_bytes=data["memory_bytes"],
+        sampled_at=datetime.datetime.fromisoformat(data["sampled_at"]),
+    )

--- a/threadmill/backends/redis.py
+++ b/threadmill/backends/redis.py
@@ -7,6 +7,7 @@ import json
 import logging
 import queue
 import time
+import typing
 import uuid
 from collections.abc import Generator, Sequence
 from pathlib import Path
@@ -116,6 +117,10 @@ class RedisBroker(Broker):
                 logger.exception("Telemetry trim error for queue %r", queue_name)
 
 
+WORKER_TELEMETRY_CHANNEL = "{prefix}:worker-telemetry"
+WORKER_TELEMETRY_TTL = 10  # seconds before stale entries are pruned
+
+
 class RedisTaskBackend(ThreadmillTaskBackend):
     """Redis-backed durable priority queue backend.
 
@@ -139,9 +144,6 @@ class RedisTaskBackend(ThreadmillTaskBackend):
     SUCCESSFUL_RESULTS_KEY = "{prefix}:results:{queue_name}:successful"
     FAILED_RESULTS_KEY = "{prefix}:results:{queue_name}:failed"
     INGRESS_KEY = "{prefix}:ingress:{queue_name}:events"
-    WORKER_TELEMETRY_KEY = "{prefix}:worker-telemetry:{hostname}:{pid}"
-    WORKER_TELEMETRY_PATTERN = "{prefix}:worker-telemetry:*"
-    WORKER_TELEMETRY_TTL = 10  # seconds before stale keys expire
 
     ACQUIRE_SCRIPT = _load_lua("acquire")
     """Pop the next task from a priority queue and move it directly to the running set."""
@@ -157,6 +159,7 @@ class RedisTaskBackend(ThreadmillTaskBackend):
             raise ValueError(
                 f"REDIS_URL must be specified in your settings for the {type(self).__name__}."
             ) from e
+        self.redis_url = redis_url
         self.client = redis.from_url(redis_url)
         self.key_prefix = f"threadmill:{{{alias}}}"
         self.lease_ttl = self.options.get("lease_ttl", datetime.timedelta(hours=1))
@@ -473,19 +476,14 @@ class RedisTaskBackend(ThreadmillTaskBackend):
         return BackendTelemetry(queues=queues)
 
     def publish_worker_telemetry(self, telemetry: WorkerTelemetry) -> None:
-        """Store a worker telemetry snapshot in Redis with a short TTL.
+        """Publish a worker telemetry snapshot via Redis pub/sub.
 
-        Each worker process writes its own key so the inspector can scan
-        and merge all active snapshots.  Keys expire automatically when a
-        worker stops reporting.
+        Each worker process publishes its own snapshot on the shared
+        channel.  The inspector subscribes and merges snapshots in-memory.
         """
+        channel = WORKER_TELEMETRY_CHANNEL.format(prefix=self.key_prefix)
         for hostname, node in telemetry.nodes.items():
             for worker_name, worker in node.workers.items():
-                key = self.WORKER_TELEMETRY_KEY.format(
-                    prefix=self.key_prefix,
-                    hostname=hostname,
-                    pid=worker.pid,
-                )
                 payload = _serialize_worker_telemetry(
                     WorkerTelemetry(
                         nodes={
@@ -506,51 +504,38 @@ class RedisTaskBackend(ThreadmillTaskBackend):
                         sampled_at=telemetry.sampled_at,
                     )
                 )
-                self.client.set(key, payload, ex=self.WORKER_TELEMETRY_TTL)
+                self.client.publish(channel, payload)
 
-    def worker_telemetry(self) -> WorkerTelemetry:
-        """Read and merge all worker telemetry snapshots from Redis.
+    async def subscribe_worker_telemetry(self) -> typing.AsyncIterator[WorkerTelemetry]:
+        """Yield worker telemetry snapshots from a persistent Redis pub/sub subscription.
 
-        Returns an empty snapshot when no workers have reported so the
-        inspector can render the worker view before any workers are running.
+        Each message is a per-worker snapshot; the caller merges them
+        in-memory and prunes stale entries.
+
+        Uses ``get_message`` with a short timeout instead of ``listen()`` so
+        the loop remains cancellable (e.g. when the inspector shuts down).
         """
-        pattern = self.WORKER_TELEMETRY_PATTERN.format(prefix=self.key_prefix)
-        keys = list(self.client.scan_iter(match=pattern))
-        if not keys:
-            return WorkerTelemetry(
-                nodes={},
-                queues={},
-                sampled_at=datetime.datetime.now(tz=datetime.UTC),
-            )
-        nodes: dict[str, NodeTelemetry] = {}
-        queues: dict[str, set[str]] = {}
-        sampled_at = datetime.datetime.now(tz=datetime.UTC)
-        for key in keys:
-            payload = self.client.get(key)
-            if not payload:
-                continue
-            if isinstance(payload, bytes):
-                payload = payload.decode()
-            snapshot = _deserialize_worker_telemetry(payload)
-            for hostname, node in snapshot.nodes.items():
-                if hostname in nodes:
-                    nodes[hostname].workers.update(node.workers)
-                    nodes[hostname].queues = tuple(
-                        sorted(set(nodes[hostname].queues) | set(node.queues))
+        import redis.asyncio as aioredis
+
+        redis_url = self.redis_url
+        channel = WORKER_TELEMETRY_CHANNEL.format(prefix=self.key_prefix)
+        async with aioredis.from_url(redis_url) as client:
+            pubsub = client.pubsub()
+            await pubsub.subscribe(channel)
+            try:
+                while True:
+                    message = await pubsub.get_message(
+                        timeout=1.0, ignore_subscribe_messages=True
                     )
-                    nodes[hostname].process_count += node.process_count
-                    nodes[hostname].thread_count += node.thread_count
-                else:
-                    nodes[hostname] = node
-                for queue_name in node.queues:
-                    queues.setdefault(queue_name, set()).add(hostname)
-            if snapshot.sampled_at > sampled_at:
-                sampled_at = snapshot.sampled_at
-        return WorkerTelemetry(
-            nodes=nodes,
-            queues={name: tuple(sorted(hosts)) for name, hosts in queues.items()},
-            sampled_at=sampled_at,
-        )
+                    if message is None:
+                        continue
+                    payload = message["data"]
+                    if isinstance(payload, bytes):
+                        payload = payload.decode()
+                    yield _deserialize_worker_telemetry(payload)
+            finally:
+                await pubsub.unsubscribe(channel)
+                await pubsub.aclose()
 
     def close(self) -> None:
         """Close the Redis connection."""

--- a/threadmill/executor.py
+++ b/threadmill/executor.py
@@ -23,6 +23,8 @@ from django.tasks.signals import task_finished, task_started
 from django.utils import timezone
 from django.utils.json import normalize_json
 
+from .telemetry import TelemetrySampler
+
 if typing.TYPE_CHECKING:
     from .backends.base import Broker, ThreadmillTaskBackend
 
@@ -145,6 +147,7 @@ class WorkerProcess(multiprocessing.Process):
         self.task_count = 0
         self.lock: threading.Lock | None = None
         self.expired: threading.Event | None = None
+        self.telemetry_sampler: TelemetrySampler | None = None
 
     def run(self) -> None:
         """Start consumer execution inside this process."""
@@ -152,6 +155,8 @@ class WorkerProcess(multiprocessing.Process):
         self.lock = threading.Lock()
         self.expired = threading.Event()
         backend = task_backends[self.backend_alias]
+        self.telemetry_sampler = TelemetrySampler(backend, worker_process=self)
+        self.telemetry_sampler.start()
         consumer_threads = [
             WorkerThread(worker=self, index=index, backend=backend)
             for index in range(self.thread_count)
@@ -162,6 +167,7 @@ class WorkerProcess(multiprocessing.Process):
             consumer_thread.join(
                 backend.result_ttl.total_seconds() if backend.result_ttl else None
             )
+        self.telemetry_sampler.stop()
 
     def record_task(self) -> None:
         """Record one processed task and stop when max_tasks is reached."""

--- a/threadmill/inspector/app.py
+++ b/threadmill/inspector/app.py
@@ -462,7 +462,8 @@ class WorkerGraphs(Static):
         self._refresh_graphs()
 
     def watch_telemetry(self) -> None:
-        self._refresh_graphs()
+        """Redraw graphs from the latest telemetry without appending a sample."""
+        self._refresh_graphs(redraw_only=True)
 
     def _reset_histories(self) -> None:
         """Clear all histories back to pre-filled zeros."""
@@ -474,8 +475,14 @@ class WorkerGraphs(Static):
             history.clear()
             history.extend([0.0] * self.GRAPH_HISTORY_SIZE)
 
-    def _refresh_graphs(self) -> None:
-        """Append the current sample to each graph and redraw."""
+    def _refresh_graphs(self, *, redraw_only: bool = False) -> None:
+        """Append the current sample to each graph and redraw.
+
+        When *redraw_only* is True (e.g. when a pub/sub message updates
+        the telemetry reactive mid-cycle), the deques are not modified;
+        only the sparkline widgets are re-rendered so the user sees the
+        latest node values without consuming a history slot.
+        """
         telemetry = self.telemetry
         selection = self.selection
         if telemetry is None or selection is None:
@@ -483,9 +490,10 @@ class WorkerGraphs(Static):
         node = telemetry.nodes.get(selection.hostname)
         if node is None or selection.kind != "node":
             return
-        self._throughput_history.append(node.tasks_per_minute)
-        self._cpu_history.append(node.cpu_percent)
-        self._memory_history.append(node.memory_percent)
+        if not redraw_only:
+            self._throughput_history.append(node.tasks_per_minute)
+            self._cpu_history.append(node.cpu_percent)
+            self._memory_history.append(node.memory_percent)
         self._update_border_titles(node)
         try:
             throughput = self.query_one("#worker-throughput-graph", Sparkline)
@@ -551,6 +559,7 @@ class InspectorApp(App):
         self._worker_graphs: WorkerGraphs | None = None
         self._telemetry_timer = None
         self._auto_refresh = auto_refresh
+        self._telemetry_cache: dict[tuple[str, int], NodeTelemetry] = {}
         self.set_reactive(InspectorApp.backend, backend)
 
     def compose(self) -> ComposeResult:
@@ -595,12 +604,18 @@ class InspectorApp(App):
         self._worker_graphs = self.query_one("#worker-graphs", WorkerGraphs)
         self._refresh_options()
         self._refresh_telemetry()
+        self.worker_telemetry = WorkerTelemetry(
+            nodes={},
+            queues={},
+            sampled_at=datetime.datetime.now(tz=datetime.UTC),
+        )
         if self._auto_refresh:
             self._telemetry_timer = self.set_interval(
                 TELEMETRY_INTERVAL_SECONDS,
                 self._refresh_telemetry,
                 name="telemetry-refresh",
             )
+            self.run_worker(self._subscribe_worker_telemetry, group="telemetry")
         self._apply_worker_view_visibility()
         self._queue_list.focus()
 
@@ -687,12 +702,66 @@ class InspectorApp(App):
         self._options_static.update(" ".join(parts) or "No options")
 
     def _refresh_telemetry(self) -> None:
-        """Poll the backend for fresh queue and worker telemetry."""
+        """Poll the backend for fresh queue telemetry and sample worker graphs."""
         try:
             self.telemetry = self.backend.telemetry()
         except Exception:  # noqa: BLE001
             logger.exception("Failed to refresh telemetry")
+        self._worker_graphs._refresh_graphs()
+
+    async def _subscribe_worker_telemetry(self) -> None:
+        """Maintain a persistent pub/sub subscription for worker telemetry.
+
+        Each message carries a per-worker snapshot; we merge them into
+        an in-memory cache keyed by (hostname, pid) and prune stale entries.
+        """
+        from ..backends.redis import WORKER_TELEMETRY_TTL as _TTL
+
         try:
-            self.worker_telemetry = self.backend.worker_telemetry()
+            async for snapshot in self.backend.subscribe_worker_telemetry():
+                self._merge_worker_telemetry(snapshot)
+                self._prune_stale_telemetry(_TTL)
+                self.worker_telemetry = self._build_merged_telemetry()
         except Exception:  # noqa: BLE001
-            logger.exception("Failed to refresh worker telemetry")
+            logger.exception("Worker telemetry subscription failed")
+
+    def _merge_worker_telemetry(self, snapshot: WorkerTelemetry) -> None:
+        """Merge a per-worker snapshot into the in-memory cache."""
+        for hostname, node in snapshot.nodes.items():
+            for _worker_name, worker in node.workers.items():
+                self._telemetry_cache[(hostname, worker.pid)] = node
+
+    def _prune_stale_telemetry(self, ttl_seconds: int) -> None:
+        """Remove cache entries older than the TTL."""
+        cutoff = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(
+            seconds=ttl_seconds
+        )
+        self._telemetry_cache = {
+            key: node
+            for key, node in self._telemetry_cache.items()
+            if node.sampled_at > cutoff
+        }
+
+    def _build_merged_telemetry(self) -> WorkerTelemetry:
+        """Build a unified WorkerTelemetry from the in-memory cache."""
+        nodes: dict[str, NodeTelemetry] = {}
+        queues: dict[str, set[str]] = {}
+        for (hostname, _pid), node in self._telemetry_cache.items():
+            if hostname in nodes:
+                existing = nodes[hostname]
+                nodes[hostname] = dataclasses.replace(
+                    existing,
+                    workers={**existing.workers, **node.workers},
+                    queues=tuple(sorted(set(existing.queues) | set(node.queues))),
+                    process_count=existing.process_count + node.process_count,
+                    thread_count=existing.thread_count + node.thread_count,
+                )
+            else:
+                nodes[hostname] = node
+            for queue_name in node.queues:
+                queues.setdefault(queue_name, set()).add(hostname)
+        return WorkerTelemetry(
+            nodes=nodes,
+            queues={name: tuple(sorted(hosts)) for name, hosts in queues.items()},
+            sampled_at=datetime.datetime.now(tz=datetime.UTC),
+        )

--- a/threadmill/inspector/app.py
+++ b/threadmill/inspector/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import datetime
 import logging
 import math
@@ -26,12 +27,19 @@ from textual.widgets import (
     ListItem,
     ListView,
     Select,
+    Sparkline,
     Static,
     TabbedContent,
     TabPane,
+    Tree,
 )
+from textual.widgets.tree import TreeNode
 
-from ..backends.base import BackendTelemetry, ThreadmillTaskBackend
+from ..backends.base import (
+    BackendTelemetry,
+    ThreadmillTaskBackend,
+    WorkerTelemetry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -340,6 +348,175 @@ class QueueList(ListView):
         self.app._task_list.queue_name = queue_name
 
 
+@dataclasses.dataclass
+class WorkerTreeNode:
+    """A node in the Queue -> Node -> Worker selection tree."""
+
+    kind: str
+    label: str
+    queue_name: str = ""
+    hostname: str = ""
+    worker_name: str = ""
+
+
+class SelectionTree(Tree[WorkerTreeNode]):
+    """Queue -> Node -> Worker hierarchy built from worker telemetry."""
+
+    telemetry: reactive[WorkerTelemetry | None] = reactive(None)
+
+    def compose(self) -> ComposeResult:
+        yield from super().compose()
+        self.border_title = "Selection"
+        self.show_root = False
+
+    def watch_telemetry(self, telemetry: WorkerTelemetry | None) -> None:
+        """Rebuild the tree when a new telemetry snapshot arrives."""
+        if telemetry is not None:
+            self.update_telemetry(telemetry)
+
+    def update_telemetry(self, telemetry: WorkerTelemetry) -> None:
+        """Rebuild the tree from a telemetry snapshot, preserving the cursor."""
+        previous_data = self.cursor_node.data if self.cursor_node else None
+        self.clear()
+        for queue_name in sorted(telemetry.queues):
+            queue_node = self.root.add(
+                queue_name,
+                WorkerTreeNode(
+                    kind="queue",
+                    label=queue_name,
+                    queue_name=queue_name,
+                ),
+                expand=True,
+            )
+            for hostname in telemetry.queues[queue_name]:
+                node_telemetry = telemetry.nodes.get(hostname)
+                if node_telemetry is None:
+                    continue
+                host_label = f"{hostname}  cpu {node_telemetry.cpu_percent:.0f}%  mem {si_prefix(node_telemetry.memory_bytes)}B"
+                host_node = queue_node.add(
+                    host_label,
+                    WorkerTreeNode(
+                        kind="node",
+                        label=host_label,
+                        queue_name=queue_name,
+                        hostname=hostname,
+                    ),
+                    expand=True,
+                )
+                for worker_name, worker in sorted(node_telemetry.workers.items()):
+                    worker_label = (
+                        f"{worker_name}  "
+                        f"cpu {worker.cpu_percent:.0f}%  "
+                        f"mem {si_prefix(worker.memory_bytes)}B  "
+                        f"{worker.tasks_per_minute:.0f}/min"
+                    )
+                    host_node.add_leaf(
+                        worker_label,
+                        WorkerTreeNode(
+                            kind="worker",
+                            label=worker_label,
+                            queue_name=queue_name,
+                            hostname=hostname,
+                            worker_name=worker_name,
+                        ),
+                    )
+        self._restore_cursor(previous_data)
+
+    def _restore_cursor(self, previous_data: WorkerTreeNode | None) -> None:
+        """Move the cursor to the previously selected node, if still present."""
+        if previous_data is None or not self.root.children:
+            return
+        node = self._find_node_by_data(self.root, previous_data)
+        if node is not None:
+            self.call_after_refresh(self.select_node, node)
+
+    @staticmethod
+    def _find_node_by_data(
+        root: TreeNode[WorkerTreeNode], target: WorkerTreeNode
+    ) -> TreeNode[WorkerTreeNode] | None:
+        """Depth-first search for a tree node whose data matches *target*."""
+        for child in root.children:
+            if child.data == target:
+                return child
+            result = SelectionTree._find_node_by_data(child, target)
+            if result is not None:
+                return result
+        return None
+
+
+class WorkerGraphs(Static):
+    """Fixed-position throughput/CPU/memory graphs for the worker view."""
+
+    telemetry: reactive[WorkerTelemetry | None] = reactive(None)
+    selection: reactive[WorkerTreeNode | None] = reactive(None)
+
+    GRAPH_HISTORY_SIZE = 60
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._throughput_history: list[float] = []
+        self._cpu_history: list[float] = []
+        self._memory_history: list[float] = []
+
+    def compose(self) -> ComposeResult:
+        yield from super().compose()
+        self.border_title = "Worker Graphs"
+        yield Sparkline(id="worker-throughput-graph", data=[])
+        yield Sparkline(id="worker-cpu-graph", data=[])
+        yield Sparkline(id="worker-memory-graph", data=[])
+
+    def watch_selection(self) -> None:
+        """Reset histories when the selection changes."""
+        self._throughput_history = []
+        self._cpu_history = []
+        self._memory_history = []
+        self._refresh_graphs()
+
+    def watch_telemetry(self) -> None:
+        self._refresh_graphs()
+
+    def _refresh_graphs(self) -> None:
+        """Append the current sample to each graph and redraw."""
+        telemetry = self.telemetry
+        selection = self.selection
+        if telemetry is None or selection is None:
+            return
+        node = telemetry.nodes.get(selection.hostname)
+        if node is None:
+            return
+        if selection.kind == "node":
+            throughput = node.tasks_per_minute
+            cpu = node.cpu_percent
+            memory = node.memory_percent
+        elif selection.kind == "worker":
+            worker = node.workers.get(selection.worker_name)
+            if worker is None:
+                return
+            throughput = worker.tasks_per_minute
+            cpu = worker.cpu_percent
+            memory = worker.memory_bytes
+        else:
+            return
+        self._throughput_history.append(throughput)
+        self._cpu_history.append(cpu)
+        self._memory_history.append(memory)
+        self._throughput_history = self._throughput_history[-self.GRAPH_HISTORY_SIZE :]
+        self._cpu_history = self._cpu_history[-self.GRAPH_HISTORY_SIZE :]
+        self._memory_history = self._memory_history[-self.GRAPH_HISTORY_SIZE :]
+        try:
+            self.query_one("#worker-throughput-graph", Sparkline).data = list(
+                self._throughput_history
+            )
+            self.query_one("#worker-cpu-graph", Sparkline).data = list(
+                self._cpu_history
+            )
+            self.query_one("#worker-memory-graph", Sparkline).data = list(
+                self._memory_history
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("Worker graph widgets not yet mounted")
+
+
 class InspectorApp(App):
     """Threadmill TUI inspector with backend/queue/task panes."""
 
@@ -347,6 +524,7 @@ class InspectorApp(App):
     BINDINGS = [
         Binding("q", "quit", "Quit"),
         Binding("f5", "refresh", "Refresh"),
+        Binding("v", "toggle_view", "Toggle View"),
         *(
             Binding(key, f"switch_tab('tab-{tab_id}')", tab_id.capitalize())
             for tab_id, key in TAB_KEYS.items()
@@ -355,6 +533,10 @@ class InspectorApp(App):
 
     backend: reactive[ThreadmillTaskBackend] = reactive(None)
     telemetry: reactive[BackendTelemetry] = reactive(None, always_update=True)
+    worker_telemetry: reactive[WorkerTelemetry | None] = reactive(
+        None, always_update=True
+    )
+    worker_view_enabled: reactive[bool] = reactive(False)
 
     def __init__(
         self,
@@ -367,6 +549,8 @@ class InspectorApp(App):
         self._task_list: TaskList | None = None
         self._task_detail: TaskDetail | None = None
         self._options_static: Static | None = None
+        self._selection_tree: SelectionTree | None = None
+        self._worker_graphs: WorkerGraphs | None = None
         self._telemetry_timer = None
         self._auto_refresh = auto_refresh
         self.set_reactive(InspectorApp.backend, backend)
@@ -388,12 +572,18 @@ class InspectorApp(App):
                     yield QueueList(id="queue-list").data_bind(
                         telemetry=InspectorApp.telemetry
                     )
+                    yield SelectionTree(
+                        "Worker Telemetry", id="selection-tree"
+                    ).data_bind(telemetry=InspectorApp.worker_telemetry)
                 with Vertical(id="right-pane"):
                     yield TaskList(id="task-list").data_bind(
                         backend=InspectorApp.backend,
                         telemetry=InspectorApp.telemetry,
                     )
                     yield TaskDetail(id="task-detail", name="Task Detail")
+                    yield WorkerGraphs(id="worker-graphs").data_bind(
+                        telemetry=InspectorApp.worker_telemetry,
+                    )
         yield Footer(show_command_palette=True)
 
     def on_mount(self) -> None:
@@ -403,6 +593,8 @@ class InspectorApp(App):
         self._task_list = self.query_one("#task-list", TaskList)
         self._task_detail = self.query_one("#task-detail", TaskDetail)
         self._options_static = self.query_one("#backend-options", Static)
+        self._selection_tree = self.query_one("#selection-tree", SelectionTree)
+        self._worker_graphs = self.query_one("#worker-graphs", WorkerGraphs)
         self._refresh_options()
         self._refresh_telemetry()
         if self._auto_refresh:
@@ -411,6 +603,7 @@ class InspectorApp(App):
                 self._refresh_telemetry,
                 name="telemetry-refresh",
             )
+        self._apply_worker_view_visibility()
         self._queue_list.focus()
 
     def action_quit(self) -> None:
@@ -425,6 +618,36 @@ class InspectorApp(App):
     def action_switch_tab(self, tab_id: str) -> None:
         """Activate the task status tab matching the given id."""
         self._task_list.switch_tab(tab_id)
+
+    def action_toggle_view(self) -> None:
+        """Switch between queue view and worker view."""
+        self.worker_view_enabled = not self.worker_view_enabled
+
+    def watch_worker_view_enabled(self, enabled: bool) -> None:
+        """Show/hide widgets when the view mode changes."""
+        self._apply_worker_view_visibility()
+
+    def _apply_worker_view_visibility(self) -> None:
+        """Toggle display of queue vs worker widgets."""
+        if self.worker_view_enabled:
+            self._queue_list.display = False
+            self._task_list.display = False
+            self._task_detail.display = False
+            self._selection_tree.display = True
+            self._worker_graphs.display = True
+            self._selection_tree.focus()
+        else:
+            self._queue_list.display = True
+            self._task_list.display = True
+            self._task_detail.display = True
+            self._selection_tree.display = False
+            self._worker_graphs.display = False
+            self._queue_list.focus()
+
+    def on_tree_node_selected(self, event: Tree.NodeSelected) -> None:
+        """Update worker graphs when a tree node is selected."""
+        if event.node.data is not None and isinstance(event.node.data, WorkerTreeNode):
+            self._worker_graphs.selection = event.node.data
 
     def watch_backend(self) -> None:
         self._refresh_options()
@@ -456,8 +679,12 @@ class InspectorApp(App):
         self._options_static.update(" ".join(parts) or "No options")
 
     def _refresh_telemetry(self) -> None:
-        """Poll the backend for fresh telemetry."""
+        """Poll the backend for fresh queue and worker telemetry."""
         try:
             self.telemetry = self.backend.telemetry()
         except Exception:  # noqa: BLE001
             logger.exception("Failed to refresh telemetry")
+        try:
+            self.worker_telemetry = self.backend.worker_telemetry()
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to refresh worker telemetry")

--- a/threadmill/inspector/app.py
+++ b/threadmill/inspector/app.py
@@ -7,6 +7,7 @@ import datetime
 import logging
 import math
 import typing
+from collections import deque
 from typing import Any
 
 from django.contrib.humanize.templatetags.humanize import naturaltime
@@ -436,26 +437,42 @@ class WorkerGraphs(Static):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self._throughput_history: list[float] = [0.0] * self.GRAPH_HISTORY_SIZE
-        self._cpu_history: list[float] = [0.0] * self.GRAPH_HISTORY_SIZE
-        self._memory_history: list[float] = [0.0] * self.GRAPH_HISTORY_SIZE
+        self._throughput_history: deque[float] = deque(
+            [0.0] * self.GRAPH_HISTORY_SIZE, maxlen=self.GRAPH_HISTORY_SIZE
+        )
+        self._cpu_history: deque[float] = deque(
+            [0.0] * self.GRAPH_HISTORY_SIZE, maxlen=self.GRAPH_HISTORY_SIZE
+        )
+        self._memory_history: deque[float] = deque(
+            [0.0] * self.GRAPH_HISTORY_SIZE, maxlen=self.GRAPH_HISTORY_SIZE
+        )
 
     def compose(self) -> ComposeResult:
         yield from super().compose()
         self.border_title = "Worker Graphs"
-        yield Sparkline(id="worker-throughput-graph", data=[])
-        yield Sparkline(id="worker-cpu-graph", data=[])
-        yield Sparkline(id="worker-memory-graph", data=[])
+        yield Sparkline(
+            id="worker-throughput-graph", data=list(self._throughput_history)
+        )
+        yield Sparkline(id="worker-cpu-graph", data=list(self._cpu_history))
+        yield Sparkline(id="worker-memory-graph", data=list(self._memory_history))
 
     def watch_selection(self) -> None:
         """Reset histories when the selection changes."""
-        self._throughput_history = [0.0] * self.GRAPH_HISTORY_SIZE
-        self._cpu_history = [0.0] * self.GRAPH_HISTORY_SIZE
-        self._memory_history = [0.0] * self.GRAPH_HISTORY_SIZE
+        self._reset_histories()
         self._refresh_graphs()
 
     def watch_telemetry(self) -> None:
         self._refresh_graphs()
+
+    def _reset_histories(self) -> None:
+        """Clear all histories back to pre-filled zeros."""
+        for history in (
+            self._throughput_history,
+            self._cpu_history,
+            self._memory_history,
+        ):
+            history.clear()
+            history.extend([0.0] * self.GRAPH_HISTORY_SIZE)
 
     def _refresh_graphs(self) -> None:
         """Append the current sample to each graph and redraw."""
@@ -469,34 +486,17 @@ class WorkerGraphs(Static):
         self._throughput_history.append(node.tasks_per_minute)
         self._cpu_history.append(node.cpu_percent)
         self._memory_history.append(node.memory_percent)
-        self._trim_histories()
         self._update_border_titles(node)
         try:
-            self.query_one(
-                "#worker-throughput-graph", Sparkline
-            ).data = self._throughput_history
-            self.query_one("#worker-cpu-graph", Sparkline).data = [
-                0.0,
-                *self._cpu_history,
-                100.0,
-            ]
-            self.query_one("#worker-memory-graph", Sparkline).data = [
-                0.0,
-                *self._memory_history,
-                100.0,
-            ]
+            throughput = self.query_one("#worker-throughput-graph", Sparkline)
+            cpu = self.query_one("#worker-cpu-graph", Sparkline)
+            mem = self.query_one("#worker-memory-graph", Sparkline)
         except Exception:  # noqa: BLE001
             logger.debug("Worker graph widgets not yet mounted")
-
-    def _trim_histories(self) -> None:
-        """Keep each history list at GRAPH_HISTORY_SIZE by dropping the oldest entry."""
-        for attr in (
-            "_throughput_history",
-            "_cpu_history",
-            "_memory_history",
-        ):
-            history = getattr(self, attr)
-            del history[: -self.GRAPH_HISTORY_SIZE]
+            return
+        throughput.data = list(self._throughput_history)
+        cpu.data = list(self._cpu_history)
+        mem.data = list(self._memory_history)
 
     def _update_border_titles(self, node: NodeTelemetry) -> None:
         """Show current values in the sparkline border titles."""

--- a/threadmill/inspector/app.py
+++ b/threadmill/inspector/app.py
@@ -37,6 +37,7 @@ from textual.widgets.tree import TreeNode
 
 from ..backends.base import (
     BackendTelemetry,
+    NodeTelemetry,
     ThreadmillTaskBackend,
     WorkerTelemetry,
 )
@@ -391,18 +392,11 @@ class SelectionTree(Tree[WorkerTreeNode]):
                 node_telemetry = telemetry.nodes.get(hostname)
                 if node_telemetry is None:
                     continue
-                host_label = (
-                    f"{hostname}  "
-                    f"cpu {node_telemetry.cpu_percent:.0f}%  "
-                    f"mem {node_telemetry.memory_percent:.0f}%  "
-                    f"procs {node_telemetry.process_count}  "
-                    f"threads {node_telemetry.thread_count}"
-                )
                 queue_node.add_leaf(
-                    host_label,
+                    hostname,
                     WorkerTreeNode(
                         kind="node",
-                        label=host_label,
+                        label=hostname,
                         queue_name=queue_name,
                         hostname=hostname,
                     ),
@@ -432,34 +426,32 @@ class SelectionTree(Tree[WorkerTreeNode]):
 
 
 class WorkerGraphs(Static):
-    """Fixed-position throughput/CPU/memory graphs for the worker view."""
+    """Throughput/CPU/memory graphs for the worker view."""
 
     telemetry: reactive[WorkerTelemetry | None] = reactive(None)
     selection: reactive[WorkerTreeNode | None] = reactive(None)
 
-    GRAPH_HISTORY_SIZE = 60
+    # 60 s of data at a 2 s sample interval = 30 data points.
+    GRAPH_HISTORY_SIZE = int(60 / TELEMETRY_INTERVAL_SECONDS)
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self._throughput_history: list[float] = []
-        self._cpu_history: list[float] = []
-        self._memory_history: list[float] = []
+        self._throughput_history: list[float] = [0.0] * self.GRAPH_HISTORY_SIZE
+        self._cpu_history: list[float] = [0.0] * self.GRAPH_HISTORY_SIZE
+        self._memory_history: list[float] = [0.0] * self.GRAPH_HISTORY_SIZE
 
     def compose(self) -> ComposeResult:
         yield from super().compose()
         self.border_title = "Worker Graphs"
-        yield Static("Throughput (tasks/min)", id="worker-throughput-label")
         yield Sparkline(id="worker-throughput-graph", data=[])
-        yield Static("CPU (%)", id="worker-cpu-label")
         yield Sparkline(id="worker-cpu-graph", data=[])
-        yield Static("Memory (%)", id="worker-memory-label")
         yield Sparkline(id="worker-memory-graph", data=[])
 
     def watch_selection(self) -> None:
         """Reset histories when the selection changes."""
-        self._throughput_history = []
-        self._cpu_history = []
-        self._memory_history = []
+        self._throughput_history = [0.0] * self.GRAPH_HISTORY_SIZE
+        self._cpu_history = [0.0] * self.GRAPH_HISTORY_SIZE
+        self._memory_history = [0.0] * self.GRAPH_HISTORY_SIZE
         self._refresh_graphs()
 
     def watch_telemetry(self) -> None:
@@ -472,28 +464,55 @@ class WorkerGraphs(Static):
         if telemetry is None or selection is None:
             return
         node = telemetry.nodes.get(selection.hostname)
-        if node is None:
-            return
-        if selection.kind != "node":
+        if node is None or selection.kind != "node":
             return
         self._throughput_history.append(node.tasks_per_minute)
         self._cpu_history.append(node.cpu_percent)
         self._memory_history.append(node.memory_percent)
-        self._throughput_history = self._throughput_history[-self.GRAPH_HISTORY_SIZE :]
-        self._cpu_history = self._cpu_history[-self.GRAPH_HISTORY_SIZE :]
-        self._memory_history = self._memory_history[-self.GRAPH_HISTORY_SIZE :]
+        self._trim_histories()
+        self._update_border_titles(node)
         try:
-            self.query_one("#worker-throughput-graph", Sparkline).data = list(
-                self._throughput_history
-            )
-            self.query_one("#worker-cpu-graph", Sparkline).data = list(
-                self._cpu_history
-            )
-            self.query_one("#worker-memory-graph", Sparkline).data = list(
-                self._memory_history
-            )
+            self.query_one(
+                "#worker-throughput-graph", Sparkline
+            ).data = self._throughput_history
+            self.query_one("#worker-cpu-graph", Sparkline).data = [
+                0.0,
+                *self._cpu_history,
+                100.0,
+            ]
+            self.query_one("#worker-memory-graph", Sparkline).data = [
+                0.0,
+                *self._memory_history,
+                100.0,
+            ]
         except Exception:  # noqa: BLE001
             logger.debug("Worker graph widgets not yet mounted")
+
+    def _trim_histories(self) -> None:
+        """Keep each history list at GRAPH_HISTORY_SIZE by dropping the oldest entry."""
+        for attr in (
+            "_throughput_history",
+            "_cpu_history",
+            "_memory_history",
+        ):
+            history = getattr(self, attr)
+            del history[: -self.GRAPH_HISTORY_SIZE]
+
+    def _update_border_titles(self, node: NodeTelemetry) -> None:
+        """Show current values in the sparkline border titles."""
+        try:
+            throughput = self.query_one("#worker-throughput-graph", Sparkline)
+            cpu = self.query_one("#worker-cpu-graph", Sparkline)
+            mem = self.query_one("#worker-memory-graph", Sparkline)
+        except Exception:  # noqa: BLE001
+            return
+        throughput.border_title = f"Throughput  {node.tasks_per_minute:.0f} tasks/min"
+        cpu.border_title = f"CPU  {node.cpu_percent:.0f}%"
+        mem.border_title = (
+            f"Memory  {node.memory_percent:.0f}%  "
+            f"{si_prefix(node.memory_bytes)}B  "
+            f"procs {node.process_count}  threads {node.thread_count}"
+        )
 
 
 class InspectorApp(App):
@@ -503,7 +522,7 @@ class InspectorApp(App):
     BINDINGS = [
         Binding("q", "quit", "Quit"),
         Binding("f5", "refresh", "Refresh"),
-        Binding("v", "toggle_view", "Toggle View"),
+        Binding("v", "toggle_view", "Toggle Worker View"),
         *(
             Binding(key, f"switch_tab('tab-{tab_id}')", tab_id.capitalize())
             for tab_id, key in TAB_KEYS.items()
@@ -603,8 +622,18 @@ class InspectorApp(App):
         self.worker_view_enabled = not self.worker_view_enabled
 
     def watch_worker_view_enabled(self, enabled: bool) -> None:
-        """Show/hide widgets when the view mode changes."""
+        """Show/hide widgets and update the toggle binding label."""
         self._apply_worker_view_visibility()
+        # Update the binding description: "Toggle Worker View" when in
+        # queue view, "Toggle Queue View" when in worker view.
+        self._bindings.key_to_bindings["v"] = [
+            Binding(
+                "v",
+                "toggle_view",
+                "Toggle Queue View" if enabled else "Toggle Worker View",
+            )
+        ]
+        self.refresh_bindings()
 
     def _apply_worker_view_visibility(self) -> None:
         """Toggle display of queue vs worker widgets."""

--- a/threadmill/inspector/app.py
+++ b/threadmill/inspector/app.py
@@ -350,17 +350,16 @@ class QueueList(ListView):
 
 @dataclasses.dataclass
 class WorkerTreeNode:
-    """A node in the Queue -> Node -> Worker selection tree."""
+    """A node in the Queue -> Node selection tree."""
 
     kind: str
     label: str
     queue_name: str = ""
     hostname: str = ""
-    worker_name: str = ""
 
 
 class SelectionTree(Tree[WorkerTreeNode]):
-    """Queue -> Node -> Worker hierarchy built from worker telemetry."""
+    """Queue -> Node hierarchy built from worker telemetry."""
 
     telemetry: reactive[WorkerTelemetry | None] = reactive(None)
 
@@ -392,8 +391,14 @@ class SelectionTree(Tree[WorkerTreeNode]):
                 node_telemetry = telemetry.nodes.get(hostname)
                 if node_telemetry is None:
                     continue
-                host_label = f"{hostname}  cpu {node_telemetry.cpu_percent:.0f}%  mem {si_prefix(node_telemetry.memory_bytes)}B"
-                host_node = queue_node.add(
+                host_label = (
+                    f"{hostname}  "
+                    f"cpu {node_telemetry.cpu_percent:.0f}%  "
+                    f"mem {node_telemetry.memory_percent:.0f}%  "
+                    f"procs {node_telemetry.process_count}  "
+                    f"threads {node_telemetry.thread_count}"
+                )
+                queue_node.add_leaf(
                     host_label,
                     WorkerTreeNode(
                         kind="node",
@@ -401,25 +406,7 @@ class SelectionTree(Tree[WorkerTreeNode]):
                         queue_name=queue_name,
                         hostname=hostname,
                     ),
-                    expand=True,
                 )
-                for worker_name, worker in sorted(node_telemetry.workers.items()):
-                    worker_label = (
-                        f"{worker_name}  "
-                        f"cpu {worker.cpu_percent:.0f}%  "
-                        f"mem {si_prefix(worker.memory_bytes)}B  "
-                        f"{worker.tasks_per_minute:.0f}/min"
-                    )
-                    host_node.add_leaf(
-                        worker_label,
-                        WorkerTreeNode(
-                            kind="worker",
-                            label=worker_label,
-                            queue_name=queue_name,
-                            hostname=hostname,
-                            worker_name=worker_name,
-                        ),
-                    )
         self._restore_cursor(previous_data)
 
     def _restore_cursor(self, previous_data: WorkerTreeNode | None) -> None:
@@ -461,8 +448,11 @@ class WorkerGraphs(Static):
     def compose(self) -> ComposeResult:
         yield from super().compose()
         self.border_title = "Worker Graphs"
+        yield Static("Throughput (tasks/min)", id="worker-throughput-label")
         yield Sparkline(id="worker-throughput-graph", data=[])
+        yield Static("CPU (%)", id="worker-cpu-label")
         yield Sparkline(id="worker-cpu-graph", data=[])
+        yield Static("Memory (%)", id="worker-memory-label")
         yield Sparkline(id="worker-memory-graph", data=[])
 
     def watch_selection(self) -> None:
@@ -484,22 +474,11 @@ class WorkerGraphs(Static):
         node = telemetry.nodes.get(selection.hostname)
         if node is None:
             return
-        if selection.kind == "node":
-            throughput = node.tasks_per_minute
-            cpu = node.cpu_percent
-            memory = node.memory_percent
-        elif selection.kind == "worker":
-            worker = node.workers.get(selection.worker_name)
-            if worker is None:
-                return
-            throughput = worker.tasks_per_minute
-            cpu = worker.cpu_percent
-            memory = worker.memory_bytes
-        else:
+        if selection.kind != "node":
             return
-        self._throughput_history.append(throughput)
-        self._cpu_history.append(cpu)
-        self._memory_history.append(memory)
+        self._throughput_history.append(node.tasks_per_minute)
+        self._cpu_history.append(node.cpu_percent)
+        self._memory_history.append(node.memory_percent)
         self._throughput_history = self._throughput_history[-self.GRAPH_HISTORY_SIZE :]
         self._cpu_history = self._cpu_history[-self.GRAPH_HISTORY_SIZE :]
         self._memory_history = self._memory_history[-self.GRAPH_HISTORY_SIZE :]

--- a/threadmill/inspector/app.py
+++ b/threadmill/inspector/app.py
@@ -702,18 +702,20 @@ class InspectorApp(App):
         self._options_static.update(" ".join(parts) or "No options")
 
     def _refresh_telemetry(self) -> None:
-        """Poll the backend for fresh queue telemetry and sample worker graphs."""
+        """Poll backend for queue telemetry, publish merged worker telemetry, sample graphs."""
         try:
             self.telemetry = self.backend.telemetry()
         except Exception:  # noqa: BLE001
             logger.exception("Failed to refresh telemetry")
+        self._publish_merged_telemetry()
         self._worker_graphs._refresh_graphs()
 
     async def _subscribe_worker_telemetry(self) -> None:
         """Maintain a persistent pub/sub subscription for worker telemetry.
 
-        Each message carries a per-worker snapshot; we merge them into
-        an in-memory cache keyed by (hostname, pid) and prune stale entries.
+        Each message is merged into the in-memory cache silently; the
+        reactive ``worker_telemetry`` is only updated on the 2-second timer
+        tick (``_refresh_telemetry``) to avoid flooding the UI with redraws.
         """
         from ..backends.redis import WORKER_TELEMETRY_TTL as _TTL
 
@@ -721,9 +723,13 @@ class InspectorApp(App):
             async for snapshot in self.backend.subscribe_worker_telemetry():
                 self._merge_worker_telemetry(snapshot)
                 self._prune_stale_telemetry(_TTL)
-                self.worker_telemetry = self._build_merged_telemetry()
         except Exception:  # noqa: BLE001
             logger.exception("Worker telemetry subscription failed")
+
+    def _publish_merged_telemetry(self) -> None:
+        """Push the merged cache into the reactive from the timer tick."""
+        if self._telemetry_cache:
+            self.worker_telemetry = self._build_merged_telemetry()
 
     def _merge_worker_telemetry(self, snapshot: WorkerTelemetry) -> None:
         """Merge a per-worker snapshot into the in-memory cache."""

--- a/threadmill/inspector/inspector.scss
+++ b/threadmill/inspector/inspector.scss
@@ -133,3 +133,23 @@ TaskDetail {
     height: 1fr;
     width: 100%;
 }
+
+#worker-throughput-graph {
+    color: $primary;
+}
+
+#worker-cpu-graph {
+    color: $warning;
+}
+
+#worker-memory-graph {
+    color: $success;
+}
+
+#worker-throughput-label,
+#worker-cpu-label,
+#worker-memory-label {
+    color: $foreground 70%;
+    padding: 0 1;
+    height: 1;
+}

--- a/threadmill/inspector/inspector.scss
+++ b/threadmill/inspector/inspector.scss
@@ -104,3 +104,32 @@ TaskDetail {
     overflow: scroll;
     padding: 0 1;
 }
+
+#selection-tree {
+    height: 1fr;
+    width: 100%;
+    border: round $accent 40%;
+    border-title-color: $primary;
+    border-title-align: right;
+    background: $background;
+    padding: 0 1;
+
+    &:focus-within {
+        border: round $accent 100%;
+    }
+}
+
+#worker-graphs {
+    height: 40%;
+    width: 100%;
+    border: round $accent 40%;
+    border-title-color: $primary;
+    border-title-align: right;
+    background: $background;
+    padding: 0 1;
+}
+
+#worker-graphs Sparkline {
+    height: 1fr;
+    width: 100%;
+}

--- a/threadmill/inspector/inspector.scss
+++ b/threadmill/inspector/inspector.scss
@@ -120,8 +120,6 @@ TaskDetail {
 }
 
 #worker-graphs {
-    height: 40%;
-    width: 100%;
     border: round $accent 40%;
     border-title-color: $primary;
     border-title-align: right;
@@ -131,7 +129,9 @@ TaskDetail {
 
 #worker-graphs Sparkline {
     height: 1fr;
-    width: 100%;
+    border: round $accent 40%;
+    border-title-color: $primary;
+    border-title-align: right;
 }
 
 #worker-throughput-graph {
@@ -144,12 +144,4 @@ TaskDetail {
 
 #worker-memory-graph {
     color: $success;
-}
-
-#worker-throughput-label,
-#worker-cpu-label,
-#worker-memory-label {
-    color: $foreground 70%;
-    padding: 0 1;
-    height: 1;
 }

--- a/threadmill/telemetry.py
+++ b/threadmill/telemetry.py
@@ -1,9 +1,9 @@
-"""Worker-pool telemetry sampling via psutil and Redis pub/sub.
+"""Worker-pool telemetry sampling via psutil and a Redis key store.
 
 The :class:`TelemetrySampler` runs inside each worker process. It periodically
-samples the process and node CPU/memory plus the rolling task throughput, then
-publishes a :class:`~threadmill.backends.base.WorkerTelemetry` snapshot through
-the backend's :meth:`publish_worker_telemetry` hook. ``psutil`` is an optional
+samples the node CPU/memory plus the rolling task throughput, then publishes a
+:class:`~threadmill.backends.base.WorkerTelemetry` snapshot through the
+backend's :meth:`publish_worker_telemetry` hook. ``psutil`` is an optional
 dependency; when it is missing the sampler is a silent no-op so the worker
 command still functions.
 """
@@ -84,9 +84,8 @@ class TelemetrySampler:
             self._thread = None
 
     def _run(self) -> None:
-        # Prime the CPU percent counters so the first sample is meaningful.
+        # Prime the CPU percent counter so the first sample is meaningful.
         psutil.cpu_percent(interval=None)
-        psutil.Process().cpu_percent(interval=None)
         while not self._stop_requested.wait(self.interval_seconds):
             try:
                 self._publish_one_sample()
@@ -102,7 +101,6 @@ class TelemetrySampler:
         now = datetime.datetime.now(tz=datetime.UTC)
         now_monotonic = self._clock()
 
-        process = psutil.Process()
         worker_name = self.worker_process.name
         queues = tuple(self.worker_process.queues)
         thread_count = self.worker_process.thread_count
@@ -111,13 +109,11 @@ class TelemetrySampler:
         tasks_per_minute = self._tasks_per_minute(task_count, now_monotonic)
         worker = WorkerProcessTelemetry(
             name=worker_name,
-            pid=self.worker_process.pid or process.pid,
+            pid=self.worker_process.pid or psutil.Process().pid,
             queues=queues,
             thread_count=thread_count,
             task_count=task_count,
             tasks_per_minute=tasks_per_minute,
-            cpu_percent=process.cpu_percent(interval=None),
-            memory_bytes=process.memory_info().rss,
             sampled_at=now,
         )
 
@@ -125,6 +121,8 @@ class TelemetrySampler:
         node = NodeTelemetry(
             hostname=socket.gethostname(),
             queues=queues,
+            process_count=1,
+            thread_count=thread_count,
             cpu_percent=psutil.cpu_percent(interval=None),
             memory_percent=virtual_memory.percent,
             memory_bytes=virtual_memory.total,

--- a/threadmill/telemetry.py
+++ b/threadmill/telemetry.py
@@ -1,0 +1,161 @@
+"""Worker-pool telemetry sampling via psutil and Redis pub/sub.
+
+The :class:`TelemetrySampler` runs inside each worker process. It periodically
+samples the process and node CPU/memory plus the rolling task throughput, then
+publishes a :class:`~threadmill.backends.base.WorkerTelemetry` snapshot through
+the backend's :meth:`publish_worker_telemetry` hook. ``psutil`` is an optional
+dependency; when it is missing the sampler is a silent no-op so the worker
+command still functions.
+"""
+
+from __future__ import annotations
+
+import collections
+import datetime
+import logging
+import socket
+import threading
+import time
+import typing
+
+from .backends.base import (
+    NodeTelemetry,
+    WorkerProcessTelemetry,
+    WorkerTelemetry,
+)
+
+logger = logging.getLogger(__name__)
+
+try:
+    import psutil
+except ImportError:  # pragma: no cover - exercised via the guarded path
+    psutil = None  # type: ignore[assignment]
+
+
+SAMPLE_INTERVAL_SECONDS = 2.0
+"""Default seconds between worker telemetry samples."""
+
+
+class TelemetrySampler:
+    """Periodically sample and publish worker-pool telemetry.
+
+    The sampler is driven by a daemon thread started in
+    :meth:`start` and stopped in :meth:`stop`. Sampling only runs when
+    ``psutil`` is importable; without it the sampler publishes nothing and the
+    worker keeps working.
+    """
+
+    def __init__(
+        self,
+        backend,
+        *,
+        worker_process,
+        interval_seconds: float = SAMPLE_INTERVAL_SECONDS,
+        clock: typing.Callable[[], float] | None = None,
+    ) -> None:
+        self.backend = backend
+        self.worker_process = worker_process
+        self.interval_seconds = interval_seconds
+        self._clock = clock or time.monotonic
+        self._stop_requested = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._task_count_previous = 0
+        self._sampled_at_previous: float | None = None
+
+    @property
+    def is_available(self) -> bool:
+        """Whether psutil is importable and sampling is active."""
+        return psutil is not None
+
+    def start(self) -> None:
+        """Start the background sampling thread, if psutil is available."""
+        if not self.is_available or self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._run, name="worker-telemetry-sampler", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Request the sampling thread to stop and wait for it to exit."""
+        self._stop_requested.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self.interval_seconds + 1)
+            self._thread = None
+
+    def _run(self) -> None:
+        # Prime the CPU percent counters so the first sample is meaningful.
+        psutil.cpu_percent(interval=None)
+        psutil.Process().cpu_percent(interval=None)
+        while not self._stop_requested.wait(self.interval_seconds):
+            try:
+                self._publish_one_sample()
+            except Exception:  # noqa: BLE001
+                logger.exception("Failed to sample worker telemetry")
+
+    def _publish_one_sample(self) -> None:
+        snapshot = self.sample()
+        self.backend.publish_worker_telemetry(snapshot)
+
+    def sample(self) -> WorkerTelemetry:
+        """Build and return one :class:`WorkerTelemetry` snapshot."""
+        now = datetime.datetime.now(tz=datetime.UTC)
+        now_monotonic = self._clock()
+
+        process = psutil.Process()
+        worker_name = self.worker_process.name
+        queues = tuple(self.worker_process.queues)
+        thread_count = self.worker_process.thread_count
+        task_count = self.worker_process.task_count
+
+        tasks_per_minute = self._tasks_per_minute(task_count, now_monotonic)
+        worker = WorkerProcessTelemetry(
+            name=worker_name,
+            pid=self.worker_process.pid or process.pid,
+            queues=queues,
+            thread_count=thread_count,
+            task_count=task_count,
+            tasks_per_minute=tasks_per_minute,
+            cpu_percent=process.cpu_percent(interval=None),
+            memory_bytes=process.memory_info().rss,
+            sampled_at=now,
+        )
+
+        virtual_memory = psutil.virtual_memory()
+        node = NodeTelemetry(
+            hostname=socket.gethostname(),
+            queues=queues,
+            cpu_percent=psutil.cpu_percent(interval=None),
+            memory_percent=virtual_memory.percent,
+            memory_bytes=virtual_memory.total,
+            tasks_per_minute=tasks_per_minute,
+            workers={worker_name: worker},
+            sampled_at=now,
+        )
+
+        queue_index: dict[str, list[str]] = collections.defaultdict(list)
+        for queue_name in queues:
+            queue_index[queue_name].append(node.hostname)
+
+        return WorkerTelemetry(
+            nodes={node.hostname: node},
+            queues={
+                queue_name: tuple(hostnames)
+                for queue_name, hostnames in queue_index.items()
+            },
+            sampled_at=now,
+        )
+
+    def _tasks_per_minute(self, task_count: int, now_monotonic: float) -> float:
+        """Compute tasks/minute from the delta since the previous sample."""
+        if self._sampled_at_previous is None:
+            self._task_count_previous = task_count
+            self._sampled_at_previous = now_monotonic
+            return 0.0
+        elapsed_seconds = now_monotonic - self._sampled_at_previous
+        if elapsed_seconds <= 0:
+            return 0.0
+        delta = task_count - self._task_count_previous
+        self._task_count_previous = task_count
+        self._sampled_at_previous = now_monotonic
+        return delta / elapsed_seconds * 60.0


### PR DESCRIPTION
Implements worker pool telemetry for the inspector TUI as requested in #18. Operators can now toggle between queue and worker views, with per-node/per-worker CPU, memory, and throughput metrics displayed in btop/htop-style graphs.


Close #18